### PR TITLE
Show results in W/D/L order on Blood Bowl dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "shealeslein.com",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/scripts/seed-dev.js
+++ b/scripts/seed-dev.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import Database from 'better-sqlite3';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DB_PATH = path.join(__dirname, '../data/bloodbowl.db');
+
+const db = new Database(DB_PATH);
+db.pragma('journal_mode = WAL');
+
+const teams    = db.prepare('SELECT id, name FROM teams').all();
+const platforms = db.prepare('SELECT id, name FROM platforms').all();
+const formats   = db.prepare('SELECT id, name, platform_id FROM formats').all();
+
+const formatsByPlatform = new Map();
+for (const f of formats) {
+  if (!formatsByPlatform.has(f.platform_id)) formatsByPlatform.set(f.platform_id, []);
+  formatsByPlatform.get(f.platform_id).push(f);
+}
+
+const opponents = [
+  'Grimbold Ironside', 'Coach McMurphy', 'The Legendary Zug', 'Darkside Cowboys',
+  'Varag Ghoul-Chewer', 'Morg N Thorg', 'Griff Oberwald', 'Puggy Baconbreath',
+  'Helmut Wulf', 'Bertha Bigfist', 'Ramtut III', 'Mummy McGee',
+  'Nobbla Blackwart', 'Deeproot Strongbranch', 'Rashnak Backstabber', 'Wilhelm Chaney',
+];
+
+const results = ['W', 'W', 'W', 'D', 'L', 'L'];
+
+function rand(arr) { return arr[Math.floor(Math.random() * arr.length)]; }
+function randInt(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
+
+function randDate() {
+  const start = new Date('2023-01-01');
+  const end   = new Date('2026-05-24');
+  const d = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
+  return d.toISOString().slice(0, 10);
+}
+
+const insert = db.prepare(`
+  INSERT INTO games (opponent_name, my_race_id, opponent_race_id, result,
+                     score_for, score_against, date, platform_id, format_id, notes)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`);
+
+const insertMany = db.transaction(() => {
+  for (let i = 0; i < 110; i++) {
+    const myRace       = rand(teams);
+    const opponentRace = rand(teams);
+    const platform     = rand(platforms);
+    const format       = rand(formatsByPlatform.get(platform.id));
+    const result       = rand(results);
+    const scoreFor     = randInt(0, 5);
+    const scoreAgainst = randInt(0, 5);
+
+    insert.run(
+      rand(opponents),
+      myRace.id,
+      opponentRace.id,
+      result,
+      scoreFor,
+      scoreAgainst,
+      randDate(),
+      platform.id,
+      format.id,
+      null,
+    );
+  }
+});
+
+insertMany();
+console.log('Inserted 110 random games into', DB_PATH);

--- a/scripts/seed-test.js
+++ b/scripts/seed-test.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Inserts a fixed set of named test games. Requires the DB to already be
+// initialized (schema + reference data). Run via:
+//   DB_PATH=data/test.db node scripts/seed-test.js
+import Database from 'better-sqlite3';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, '../data/test.db');
+
+const db = new Database(DB_PATH);
+
+const id   = (table, col, val) => db.prepare(`SELECT id FROM ${table} WHERE ${col} = ?`).get(val).id;
+const fmt  = (name, pid)       => db.prepare('SELECT id FROM formats WHERE name = ? AND platform_id = ?').get(name, pid).id;
+
+const orc      = id('teams',     'name', 'Orc');
+const human    = id('teams',     'name', 'Human');
+const dwarf    = id('teams',     'name', 'Dwarf');
+const skaven   = id('teams',     'name', 'Skaven');
+const bb3      = id('platforms', 'name', 'Blood Bowl 3');
+const fumbbl   = id('platforms', 'name', 'Fumbbl');
+const tabletop = id('platforms', 'name', 'tabletop');
+
+const ins = db.prepare(`
+  INSERT INTO games
+    (opponent_name, my_race_id, opponent_race_id, result,
+     score_for, score_against, date, platform_id, format_id, notes)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+`);
+
+db.transaction(() => {
+  ins.run('Seed W Game',    orc,   human,  'W', 2, 1, '2024-01-01', bb3,      fmt('league',     bb3));
+  ins.run('Seed D Game',    orc,   human,  'D', 0, 0, '2024-01-02', bb3,      fmt('league',     bb3));
+  ins.run('Seed L Game',    orc,   human,  'L', 1, 2, '2024-01-03', bb3,      fmt('league',     bb3));
+  ins.run('Fumbbl Game',    orc,   human,  'W', 2, 1, '2024-01-04', fumbbl,   fmt('league',     fumbbl));
+  ins.run('Ladder Game',    orc,   human,  'W', 3, 0, '2024-01-05', bb3,      fmt('ladder',     bb3));
+  ins.run('Dwarf Game',     dwarf, human,  'W', 1, 0, '2024-01-06', bb3,      fmt('league',     bb3));
+  ins.run('Skaven Game',    orc,   skaven, 'W', 2, 1, '2024-01-07', bb3,      fmt('league',     bb3));
+  ins.run('Tabletop Game',  orc,   human,  'W', 2, 0, '2024-01-08', tabletop, fmt('tournament', tabletop));
+})();
+
+db.close();
+console.log('Seeded 8 test games into', DB_PATH);

--- a/scripts/seed-test.js
+++ b/scripts/seed-test.js
@@ -38,7 +38,13 @@ db.transaction(() => {
   ins.run('Dwarf Game',     dwarf, human,  'W', 1, 0, '2024-01-06', bb3,      fmt('league',     bb3));
   ins.run('Skaven Game',    orc,   skaven, 'W', 2, 1, '2024-01-07', bb3,      fmt('league',     bb3));
   ins.run('Tabletop Game',  orc,   human,  'W', 2, 0, '2024-01-08', tabletop, fmt('tournament', tabletop));
+  // Extra BB3 games: brings total to 13 (>10 for pagination) and BB3 to 11 (>10 when platform-filtered)
+  ins.run('BB3 Extra 1',    orc,   human,  'W', 2, 1, '2024-01-09', bb3,      fmt('league',     bb3));
+  ins.run('BB3 Extra 2',    orc,   human,  'W', 2, 1, '2024-01-10', bb3,      fmt('league',     bb3));
+  ins.run('BB3 Extra 3',    orc,   human,  'W', 2, 1, '2024-01-11', bb3,      fmt('league',     bb3));
+  ins.run('BB3 Extra 4',    orc,   human,  'W', 2, 1, '2024-01-12', bb3,      fmt('league',     bb3));
+  ins.run('BB3 Extra 5',    orc,   human,  'W', 2, 1, '2024-01-13', bb3,      fmt('league',     bb3));
 })();
 
 db.close();
-console.log('Seeded 8 test games into', DB_PATH);
+console.log('Seeded 13 test games into', DB_PATH);

--- a/src/components/StatsCard.astro
+++ b/src/components/StatsCard.astro
@@ -19,9 +19,9 @@ const { overall, byRace } = Astro.props;
   <div class="overall">
     <span class="w">{overall.w}W</span>
     <span class="sep">/</span>
-    <span class="l">{overall.l}L</span>
-    <span class="sep">/</span>
     <span class="d">{overall.d}D</span>
+    <span class="sep">/</span>
+    <span class="l">{overall.l}L</span>
   </div>
 
   {byRace.length > 0 && (
@@ -30,8 +30,8 @@ const { overall, byRace } = Astro.props;
         <tr>
           <th>Race</th>
           <th>W</th>
-          <th>L</th>
           <th>D</th>
+          <th>L</th>
         </tr>
       </thead>
       <tbody>
@@ -39,8 +39,8 @@ const { overall, byRace } = Astro.props;
           <tr>
             <td>{r.race}</td>
             <td class="w">{r.w}</td>
-            <td class="l">{r.l}</td>
             <td class="d">{r.d}</td>
+            <td class="l">{r.l}</td>
           </tr>
         ))}
       </tbody>

--- a/src/pages/blood-bowl/index.astro
+++ b/src/pages/blood-bowl/index.astro
@@ -15,16 +15,28 @@ const filterOpponentRace = Astro.url.searchParams.get('opponent_race') || '';
 
 const games = allGames.filter(g => {
   if (filterPlatform     && g.platform      !== filterPlatform)     return false;
-  if (filterFormat       && g.format        !== filterFormat)       return false;
+  if (resolvedFormat     && g.format        !== resolvedFormat)     return false;
   if (filterMyRace       && g.my_race       !== filterMyRace)       return false;
   if (filterOpponentRace && g.opponent_race !== filterOpponentRace) return false;
   return true;
 });
 
 const uniquePlatforms     = [...new Set(allGames.map(g => g.platform))].sort();
-const uniqueFormats       = [...new Set(allGames.map(g => g.format))].sort();
 const uniqueMyRaces       = [...new Set(allGames.map(g => g.my_race))].sort();
 const uniqueOpponentRaces = [...new Set(allGames.map(g => g.opponent_race))].sort();
+
+// Build platform → sorted formats map for both server-side filtering and client-side JS
+const formatsByPlatform: Record<string, string[]> = {};
+for (const g of allGames) {
+  if (!formatsByPlatform[g.platform]) formatsByPlatform[g.platform] = [];
+  if (!formatsByPlatform[g.platform].includes(g.format)) formatsByPlatform[g.platform].push(g.format);
+}
+for (const p of Object.keys(formatsByPlatform)) formatsByPlatform[p].sort();
+
+const allFormats    = [...new Set(allGames.map(g => g.format))].sort();
+const activeFormats = filterPlatform ? (formatsByPlatform[filterPlatform] ?? []) : allFormats;
+// Reset format filter if it's not valid for the selected platform
+const resolvedFormat = filterPlatform && !activeFormats.includes(filterFormat) ? '' : filterFormat;
 
 const overall = { w: 0, l: 0, d: 0 };
 const raceMap = new Map<string, { w: number; l: number; d: number }>();
@@ -52,12 +64,12 @@ const totalPages = Math.max(1, Math.ceil(games.length / PAGE_SIZE));
 const page = Math.min(Math.max(1, Number(Astro.url.searchParams.get('page')) || 1), totalPages);
 const pagedGames = games.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
-const hasFilters = !!(filterPlatform || filterFormat || filterMyRace || filterOpponentRace);
+const hasFilters = !!(filterPlatform || resolvedFormat || filterMyRace || filterOpponentRace);
 
 function pageUrl(p: number) {
   const params = new URLSearchParams();
   if (filterPlatform)     params.set('platform',      filterPlatform);
-  if (filterFormat)       params.set('format',         filterFormat);
+  if (resolvedFormat)     params.set('format',         resolvedFormat);
   if (filterMyRace)       params.set('my_race',        filterMyRace);
   if (filterOpponentRace) params.set('opponent_race',  filterOpponentRace);
   params.set('page', String(p));
@@ -72,7 +84,7 @@ function pageUrl(p: number) {
   <form class="filters" method="get">
     <label>
       Platform
-      <select name="platform">
+      <select name="platform" id="platform-select">
         <option value="">All</option>
         {uniquePlatforms.map(p => (
           <option value={p} selected={p === filterPlatform}>{p}</option>
@@ -81,10 +93,10 @@ function pageUrl(p: number) {
     </label>
     <label>
       Format
-      <select name="format">
+      <select name="format" id="format-select">
         <option value="">All</option>
-        {uniqueFormats.map(f => (
-          <option value={f} selected={f === filterFormat}>{f}</option>
+        {activeFormats.map(f => (
+          <option value={f} selected={f === resolvedFormat}>{f}</option>
         ))}
       </select>
     </label>
@@ -123,6 +135,22 @@ function pageUrl(p: number) {
     }
   </div>
 </BaseLayout>
+
+<script define:vars={{ formatsByPlatform, allFormats }}>
+  const platformSelect = document.getElementById('platform-select');
+  const formatSelect   = document.getElementById('format-select');
+
+  platformSelect.addEventListener('change', () => {
+    const platform = platformSelect.value;
+    const formats  = platform ? (formatsByPlatform[platform] ?? []) : allFormats;
+    const current  = formatSelect.value;
+
+    formatSelect.innerHTML = '<option value="">All</option>' +
+      formats.map(f => `<option value="${f}"${f === current ? ' selected' : ''}>${f}</option>`).join('');
+
+    if (platform && !formats.includes(current)) formatSelect.value = '';
+  });
+</script>
 
 <style>
   .filters {

--- a/src/pages/blood-bowl/index.astro
+++ b/src/pages/blood-bowl/index.astro
@@ -39,6 +39,7 @@ const pagedGames = games.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
   <h1>Blood Bowl</h1>
   <StatsCard overall={overall} byRace={byRace} />
   <h2>Games</h2>
+  <p><a href="/blood-bowl/add">+ Add game</a></p>
   <GameTable games={pagedGames} />
   <div class="pagination">
     {page > 1
@@ -51,7 +52,6 @@ const pagedGames = games.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
       : <span class="disabled">Next →</span>
     }
   </div>
-  <p><a href="/blood-bowl/add">+ Add game</a></p>
 </BaseLayout>
 
 <style>

--- a/src/pages/blood-bowl/index.astro
+++ b/src/pages/blood-bowl/index.astro
@@ -28,12 +28,45 @@ for (const g of games) {
 const byRace = Array.from(raceMap.entries())
   .map(([race, rec]) => ({ race, ...rec }))
   .sort((a, b) => a.race.localeCompare(b.race));
+
+const PAGE_SIZE = 10;
+const totalPages = Math.max(1, Math.ceil(games.length / PAGE_SIZE));
+const page = Math.min(Math.max(1, Number(Astro.url.searchParams.get('page')) || 1), totalPages);
+const pagedGames = games.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 ---
 
 <BaseLayout title="Blood Bowl">
   <h1>Blood Bowl</h1>
   <StatsCard overall={overall} byRace={byRace} />
   <h2>Games</h2>
-  <GameTable games={games} />
+  <GameTable games={pagedGames} />
+  <div class="pagination">
+    {page > 1
+      ? <a href={`?page=${page - 1}`}>← Prev</a>
+      : <span class="disabled">← Prev</span>
+    }
+    <span class="page-info">Page {page} of {totalPages}</span>
+    {page < totalPages
+      ? <a href={`?page=${page + 1}`}>Next →</a>
+      : <span class="disabled">Next →</span>
+    }
+  </div>
   <p><a href="/blood-bowl/add">+ Add game</a></p>
 </BaseLayout>
+
+<style>
+  .pagination {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin: 1rem 0;
+  }
+  .page-info {
+    font-size: 0.9rem;
+    color: var(--text-muted, #888);
+  }
+  .disabled {
+    color: var(--text-muted, #888);
+    cursor: default;
+  }
+</style>

--- a/src/pages/blood-bowl/index.astro
+++ b/src/pages/blood-bowl/index.astro
@@ -8,17 +8,23 @@ import { getGames } from '../../lib/queries';
 
 const allGames = getGames();
 
-const filterPlatform = Astro.url.searchParams.get('platform') || '';
-const filterFormat   = Astro.url.searchParams.get('format')   || '';
+const filterPlatform    = Astro.url.searchParams.get('platform')     || '';
+const filterFormat      = Astro.url.searchParams.get('format')       || '';
+const filterMyRace      = Astro.url.searchParams.get('my_race')      || '';
+const filterOpponentRace = Astro.url.searchParams.get('opponent_race') || '';
 
 const games = allGames.filter(g => {
-  if (filterPlatform && g.platform !== filterPlatform) return false;
-  if (filterFormat   && g.format   !== filterFormat)   return false;
+  if (filterPlatform     && g.platform      !== filterPlatform)     return false;
+  if (filterFormat       && g.format        !== filterFormat)       return false;
+  if (filterMyRace       && g.my_race       !== filterMyRace)       return false;
+  if (filterOpponentRace && g.opponent_race !== filterOpponentRace) return false;
   return true;
 });
 
-const uniquePlatforms = [...new Set(allGames.map(g => g.platform))].sort();
-const uniqueFormats   = [...new Set(allGames.map(g => g.format))].sort();
+const uniquePlatforms     = [...new Set(allGames.map(g => g.platform))].sort();
+const uniqueFormats       = [...new Set(allGames.map(g => g.format))].sort();
+const uniqueMyRaces       = [...new Set(allGames.map(g => g.my_race))].sort();
+const uniqueOpponentRaces = [...new Set(allGames.map(g => g.opponent_race))].sort();
 
 const overall = { w: 0, l: 0, d: 0 };
 const raceMap = new Map<string, { w: number; l: number; d: number }>();
@@ -46,10 +52,14 @@ const totalPages = Math.max(1, Math.ceil(games.length / PAGE_SIZE));
 const page = Math.min(Math.max(1, Number(Astro.url.searchParams.get('page')) || 1), totalPages);
 const pagedGames = games.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
+const hasFilters = !!(filterPlatform || filterFormat || filterMyRace || filterOpponentRace);
+
 function pageUrl(p: number) {
   const params = new URLSearchParams();
-  if (filterPlatform) params.set('platform', filterPlatform);
-  if (filterFormat)   params.set('format', filterFormat);
+  if (filterPlatform)     params.set('platform',      filterPlatform);
+  if (filterFormat)       params.set('format',         filterFormat);
+  if (filterMyRace)       params.set('my_race',        filterMyRace);
+  if (filterOpponentRace) params.set('opponent_race',  filterOpponentRace);
   params.set('page', String(p));
   return `?${params.toString()}`;
 }
@@ -78,8 +88,26 @@ function pageUrl(p: number) {
         ))}
       </select>
     </label>
+    <label>
+      My Race
+      <select name="my_race">
+        <option value="">All</option>
+        {uniqueMyRaces.map(r => (
+          <option value={r} selected={r === filterMyRace}>{r}</option>
+        ))}
+      </select>
+    </label>
+    <label>
+      Opponent Race
+      <select name="opponent_race">
+        <option value="">All</option>
+        {uniqueOpponentRaces.map(r => (
+          <option value={r} selected={r === filterOpponentRace}>{r}</option>
+        ))}
+      </select>
+    </label>
     <button type="submit">Filter</button>
-    {(filterPlatform || filterFormat) && <a href="/blood-bowl">Clear</a>}
+    {hasFilters && <a href="/blood-bowl">Clear</a>}
   </form>
   <p><a href="/blood-bowl/add">+ Add game</a></p>
   <GameTable games={pagedGames} />

--- a/src/pages/blood-bowl/index.astro
+++ b/src/pages/blood-bowl/index.astro
@@ -6,7 +6,19 @@ import StatsCard from '@components/StatsCard.astro';
 import GameTable from '@components/GameTable.astro';
 import { getGames } from '../../lib/queries';
 
-const games = getGames();
+const allGames = getGames();
+
+const filterPlatform = Astro.url.searchParams.get('platform') || '';
+const filterFormat   = Astro.url.searchParams.get('format')   || '';
+
+const games = allGames.filter(g => {
+  if (filterPlatform && g.platform !== filterPlatform) return false;
+  if (filterFormat   && g.format   !== filterFormat)   return false;
+  return true;
+});
+
+const uniquePlatforms = [...new Set(allGames.map(g => g.platform))].sort();
+const uniqueFormats   = [...new Set(allGames.map(g => g.format))].sort();
 
 const overall = { w: 0, l: 0, d: 0 };
 const raceMap = new Map<string, { w: number; l: number; d: number }>();
@@ -33,28 +45,71 @@ const PAGE_SIZE = 10;
 const totalPages = Math.max(1, Math.ceil(games.length / PAGE_SIZE));
 const page = Math.min(Math.max(1, Number(Astro.url.searchParams.get('page')) || 1), totalPages);
 const pagedGames = games.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+function pageUrl(p: number) {
+  const params = new URLSearchParams();
+  if (filterPlatform) params.set('platform', filterPlatform);
+  if (filterFormat)   params.set('format', filterFormat);
+  params.set('page', String(p));
+  return `?${params.toString()}`;
+}
 ---
 
 <BaseLayout title="Blood Bowl">
   <h1>Blood Bowl</h1>
   <StatsCard overall={overall} byRace={byRace} />
   <h2>Games</h2>
+  <form class="filters" method="get">
+    <label>
+      Platform
+      <select name="platform">
+        <option value="">All</option>
+        {uniquePlatforms.map(p => (
+          <option value={p} selected={p === filterPlatform}>{p}</option>
+        ))}
+      </select>
+    </label>
+    <label>
+      Format
+      <select name="format">
+        <option value="">All</option>
+        {uniqueFormats.map(f => (
+          <option value={f} selected={f === filterFormat}>{f}</option>
+        ))}
+      </select>
+    </label>
+    <button type="submit">Filter</button>
+    {(filterPlatform || filterFormat) && <a href="/blood-bowl">Clear</a>}
+  </form>
   <p><a href="/blood-bowl/add">+ Add game</a></p>
   <GameTable games={pagedGames} />
   <div class="pagination">
     {page > 1
-      ? <a href={`?page=${page - 1}`}>← Prev</a>
+      ? <a href={pageUrl(page - 1)}>← Prev</a>
       : <span class="disabled">← Prev</span>
     }
     <span class="page-info">Page {page} of {totalPages}</span>
     {page < totalPages
-      ? <a href={`?page=${page + 1}`}>Next →</a>
+      ? <a href={pageUrl(page + 1)}>Next →</a>
       : <span class="disabled">Next →</span>
     }
   </div>
 </BaseLayout>
 
 <style>
+  .filters {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+  .filters label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.8rem;
+    gap: 0.25rem;
+  }
   .pagination {
     display: flex;
     align-items: center;

--- a/src/pages/blood-bowl/index.astro
+++ b/src/pages/blood-bowl/index.astro
@@ -8,10 +8,22 @@ import { getGames } from '../../lib/queries';
 
 const allGames = getGames();
 
-const filterPlatform    = Astro.url.searchParams.get('platform')     || '';
-const filterFormat      = Astro.url.searchParams.get('format')       || '';
-const filterMyRace      = Astro.url.searchParams.get('my_race')      || '';
+const filterPlatform     = Astro.url.searchParams.get('platform')      || '';
+const filterFormat       = Astro.url.searchParams.get('format')        || '';
+const filterMyRace       = Astro.url.searchParams.get('my_race')       || '';
 const filterOpponentRace = Astro.url.searchParams.get('opponent_race') || '';
+
+// Build platform -> sorted formats map for both server-side filtering and client-side JS
+const formatsByPlatform: Record<string, string[]> = {};
+for (const g of allGames) {
+  if (!formatsByPlatform[g.platform]) formatsByPlatform[g.platform] = [];
+  if (!formatsByPlatform[g.platform].includes(g.format)) formatsByPlatform[g.platform].push(g.format);
+}
+for (const p of Object.keys(formatsByPlatform)) formatsByPlatform[p].sort();
+
+const allFormats    = [...new Set(allGames.map(g => g.format))].sort();
+const activeFormats = filterPlatform ? (formatsByPlatform[filterPlatform] ?? []) : allFormats;
+const resolvedFormat = filterPlatform && !activeFormats.includes(filterFormat) ? '' : filterFormat;
 
 const games = allGames.filter(g => {
   if (filterPlatform     && g.platform      !== filterPlatform)     return false;
@@ -24,19 +36,6 @@ const games = allGames.filter(g => {
 const uniquePlatforms     = [...new Set(allGames.map(g => g.platform))].sort();
 const uniqueMyRaces       = [...new Set(allGames.map(g => g.my_race))].sort();
 const uniqueOpponentRaces = [...new Set(allGames.map(g => g.opponent_race))].sort();
-
-// Build platform → sorted formats map for both server-side filtering and client-side JS
-const formatsByPlatform: Record<string, string[]> = {};
-for (const g of allGames) {
-  if (!formatsByPlatform[g.platform]) formatsByPlatform[g.platform] = [];
-  if (!formatsByPlatform[g.platform].includes(g.format)) formatsByPlatform[g.platform].push(g.format);
-}
-for (const p of Object.keys(formatsByPlatform)) formatsByPlatform[p].sort();
-
-const allFormats    = [...new Set(allGames.map(g => g.format))].sort();
-const activeFormats = filterPlatform ? (formatsByPlatform[filterPlatform] ?? []) : allFormats;
-// Reset format filter if it's not valid for the selected platform
-const resolvedFormat = filterPlatform && !activeFormats.includes(filterFormat) ? '' : filterFormat;
 
 const overall = { w: 0, l: 0, d: 0 };
 const raceMap = new Map<string, { w: number; l: number; d: number }>();
@@ -68,10 +67,10 @@ const hasFilters = !!(filterPlatform || resolvedFormat || filterMyRace || filter
 
 function pageUrl(p: number) {
   const params = new URLSearchParams();
-  if (filterPlatform)     params.set('platform',      filterPlatform);
-  if (resolvedFormat)     params.set('format',         resolvedFormat);
-  if (filterMyRace)       params.set('my_race',        filterMyRace);
-  if (filterOpponentRace) params.set('opponent_race',  filterOpponentRace);
+  if (filterPlatform)     params.set('platform',     filterPlatform);
+  if (resolvedFormat)     params.set('format',        resolvedFormat);
+  if (filterMyRace)       params.set('my_race',       filterMyRace);
+  if (filterOpponentRace) params.set('opponent_race', filterOpponentRace);
   params.set('page', String(p));
   return `?${params.toString()}`;
 }
@@ -125,13 +124,13 @@ function pageUrl(p: number) {
   <GameTable games={pagedGames} />
   <div class="pagination">
     {page > 1
-      ? <a href={pageUrl(page - 1)}>← Prev</a>
-      : <span class="disabled">← Prev</span>
+      ? <a href={pageUrl(page - 1)}>&#8592; Prev</a>
+      : <span class="disabled">&#8592; Prev</span>
     }
     <span class="page-info">Page {page} of {totalPages}</span>
     {page < totalPages
-      ? <a href={pageUrl(page + 1)}>Next →</a>
-      : <span class="disabled">Next →</span>
+      ? <a href={pageUrl(page + 1)}>Next &#8594;</a>
+      : <span class="disabled">Next &#8594;</span>
     }
   </div>
 </BaseLayout>

--- a/tests/blood-bowl.spec.ts
+++ b/tests/blood-bowl.spec.ts
@@ -11,6 +11,49 @@ test.beforeEach(() => {
   db.close();
 });
 
+type GameOverrides = Partial<{
+  opponent_name: string;
+  my_race: string;
+  opponent_race: string;
+  result: 'W' | 'L' | 'D';
+  score_for: number;
+  score_against: number;
+  date: string;
+  platform: string;
+  format: string;
+}>;
+
+function insertGame(overrides: GameOverrides = {}) {
+  const opts = {
+    opponent_name: 'Test Opponent',
+    my_race: 'Orc',
+    opponent_race: 'Human',
+    result: 'W' as const,
+    score_for: 2,
+    score_against: 1,
+    date: '2026-01-01',
+    platform: 'Blood Bowl 3',
+    format: 'league',
+    ...overrides,
+  };
+  const db = new Database(TEST_DB);
+  const myRaceId   = (db.prepare('SELECT id FROM teams     WHERE name = ?').get(opts.my_race)   as { id: number }).id;
+  const oppRaceId  = (db.prepare('SELECT id FROM teams     WHERE name = ?').get(opts.opponent_race) as { id: number }).id;
+  const platformId = (db.prepare('SELECT id FROM platforms WHERE name = ?').get(opts.platform)  as { id: number }).id;
+  const formatId   = (db.prepare('SELECT id FROM formats   WHERE name = ? AND platform_id = ?').get(opts.format, platformId) as { id: number }).id;
+  db.prepare(`
+    INSERT INTO games (opponent_name, my_race_id, opponent_race_id, result, score_for, score_against, date, platform_id, format_id, notes)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+  `).run(opts.opponent_name, myRaceId, oppRaceId, opts.result, opts.score_for, opts.score_against, opts.date, platformId, formatId);
+  db.close();
+}
+
+function insertGames(count: number, overrides: GameOverrides = {}) {
+  for (let i = 0; i < count; i++) {
+    insertGame({ opponent_name: `Opponent ${i + 1}`, ...overrides });
+  }
+}
+
 async function addGame(page: Page, opponentName: string) {
   await page.goto('/blood-bowl/add');
   await page.getByLabel('Date').fill('2026-03-21');
@@ -64,4 +107,160 @@ test('delete a game', async ({ page }) => {
 
   await expect(page).toHaveURL('/blood-bowl/');
   await expect(page.getByRole('main')).not.toContainText(name);
+});
+
+// --- W/D/L ordering ---
+
+test('stats card shows results in W/D/L order', async ({ page }) => {
+  insertGame({ result: 'W' });
+  insertGame({ result: 'D' });
+  insertGame({ result: 'L' });
+  await page.goto('/blood-bowl');
+
+  const text = await page.locator('.overall').textContent() ?? '';
+  expect(text.indexOf('W')).toBeLessThan(text.indexOf('D'));
+  expect(text.indexOf('D')).toBeLessThan(text.indexOf('L'));
+});
+
+// --- Add game link position ---
+
+test('add game link appears above the game table', async ({ page }) => {
+  insertGame();
+  await page.goto('/blood-bowl');
+
+  const linkY  = (await page.getByRole('link', { name: '+ Add game' }).boundingBox())!.y;
+  const tableY = (await page.getByRole('table', { name: 'Games' }).boundingBox())!.y;
+  expect(linkY).toBeLessThan(tableY);
+});
+
+// --- Pagination ---
+
+test('shows 10 games per page', async ({ page }) => {
+  insertGames(11);
+  await page.goto('/blood-bowl');
+
+  const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
+  await expect(rows).toHaveCount(11); // 1 header + 10 data rows
+});
+
+test('next link navigates to page 2', async ({ page }) => {
+  insertGames(11);
+  await page.goto('/blood-bowl');
+
+  await page.getByRole('link', { name: /Next/ }).click();
+  await expect(page).toHaveURL(/page=2/);
+
+  const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
+  await expect(rows).toHaveCount(2); // 1 header + 1 remaining game
+});
+
+test('prev link navigates back to page 1', async ({ page }) => {
+  insertGames(11);
+  await page.goto('/blood-bowl?page=2');
+
+  await page.getByRole('link', { name: /Prev/ }).click();
+  await expect(page).toHaveURL(/page=1/);
+
+  const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
+  await expect(rows).toHaveCount(11);
+});
+
+test('prev is disabled on page 1', async ({ page }) => {
+  insertGame();
+  await page.goto('/blood-bowl');
+
+  await expect(page.getByRole('link', { name: /Prev/ })).not.toBeVisible();
+  await expect(page.locator('.disabled', { hasText: 'Prev' })).toBeVisible();
+});
+
+test('next is disabled on the last page', async ({ page }) => {
+  insertGame();
+  await page.goto('/blood-bowl');
+
+  await expect(page.getByRole('link', { name: /Next/ })).not.toBeVisible();
+  await expect(page.locator('.disabled', { hasText: 'Next' })).toBeVisible();
+});
+
+// --- Filters ---
+
+test('platform filter narrows results', async ({ page }) => {
+  insertGame({ opponent_name: 'BB3 Game',    platform: 'Blood Bowl 3', format: 'league' });
+  insertGame({ opponent_name: 'Fumbbl Game', platform: 'Fumbbl',       format: 'league' });
+  await page.goto('/blood-bowl?platform=Blood+Bowl+3');
+
+  const table = page.getByRole('table', { name: 'Games' });
+  await expect(table).toContainText('BB3 Game');
+  await expect(table).not.toContainText('Fumbbl Game');
+});
+
+test('format filter narrows results', async ({ page }) => {
+  insertGame({ opponent_name: 'League Game', format: 'league'  });
+  insertGame({ opponent_name: 'Ladder Game', format: 'ladder'  });
+  await page.goto('/blood-bowl?format=league');
+
+  const table = page.getByRole('table', { name: 'Games' });
+  await expect(table).toContainText('League Game');
+  await expect(table).not.toContainText('Ladder Game');
+});
+
+test('my race filter narrows results', async ({ page }) => {
+  insertGame({ opponent_name: 'Orc Game',   my_race: 'Orc'   });
+  insertGame({ opponent_name: 'Dwarf Game', my_race: 'Dwarf' });
+  await page.goto('/blood-bowl?my_race=Orc');
+
+  const table = page.getByRole('table', { name: 'Games' });
+  await expect(table).toContainText('Orc Game');
+  await expect(table).not.toContainText('Dwarf Game');
+});
+
+test('opponent race filter narrows results', async ({ page }) => {
+  insertGame({ opponent_name: 'vs Human', opponent_race: 'Human' });
+  insertGame({ opponent_name: 'vs Skaven', opponent_race: 'Skaven' });
+  await page.goto('/blood-bowl?opponent_race=Human');
+
+  const table = page.getByRole('table', { name: 'Games' });
+  await expect(table).toContainText('vs Human');
+  await expect(table).not.toContainText('vs Skaven');
+});
+
+test('clear link resets all filters', async ({ page }) => {
+  insertGame({ opponent_name: 'BB3 Game', platform: 'Blood Bowl 3' });
+  await page.goto('/blood-bowl?platform=Blood+Bowl+3');
+
+  await page.getByRole('link', { name: 'Clear' }).click();
+  await expect(page).toHaveURL('/blood-bowl');
+});
+
+test('filters are preserved in pagination links', async ({ page }) => {
+  insertGames(11, { platform: 'Blood Bowl 3', format: 'league' });
+  await page.goto('/blood-bowl?platform=Blood+Bowl+3');
+
+  const nextHref = await page.getByRole('link', { name: /Next/ }).getAttribute('href');
+  expect(nextHref).toContain('platform=Blood+Bowl+3');
+});
+
+// --- Format options scoped to platform ---
+
+test('selecting a platform updates format options to match', async ({ page }) => {
+  insertGame({ platform: 'tabletop', format: 'tournament' });
+  await page.goto('/blood-bowl');
+
+  await page.locator('#platform-select').selectOption('tabletop');
+
+  const formatOptions = page.locator('#format-select option');
+  const labels = await formatOptions.allTextContents();
+  expect(labels).toContain('tournament');
+  // league exists for BB3/Fumbbl but not tabletop
+  expect(labels).not.toContain('league');
+});
+
+test('format dropdown shows all options when no platform selected', async ({ page }) => {
+  insertGame({ platform: 'Blood Bowl 3', format: 'league'      });
+  insertGame({ platform: 'tabletop',     format: 'tournament'  });
+  await page.goto('/blood-bowl');
+
+  const formatOptions = page.locator('#format-select option');
+  const labels = await formatOptions.allTextContents();
+  expect(labels).toContain('league');
+  expect(labels).toContain('tournament');
 });

--- a/tests/blood-bowl.spec.ts
+++ b/tests/blood-bowl.spec.ts
@@ -1,15 +1,19 @@
 import { test, expect, type Page } from '@playwright/test';
 import Database from 'better-sqlite3';
+import { execSync } from 'child_process';
 import path from 'path';
 
 const PASSWORD = process.env.BLOOD_BOWL_KEY ?? '';
-const TEST_DB = path.join(process.cwd(), 'data', 'test.db');
+const TEST_DB  = path.join(process.cwd(), 'data', 'test.db');
 
 test.beforeEach(() => {
   const db = new Database(TEST_DB);
   db.prepare('DELETE FROM games').run();
   db.close();
+  execSync('node scripts/seed-test.js', { env: { ...process.env, DB_PATH: TEST_DB } });
 });
+
+// --- Helpers for tests that need data beyond the seed ---
 
 type GameOverrides = Partial<{
   opponent_name: string;
@@ -50,9 +54,11 @@ function insertGame(overrides: GameOverrides = {}) {
 
 function insertGames(count: number, overrides: GameOverrides = {}) {
   for (let i = 0; i < count; i++) {
-    insertGame({ opponent_name: `Opponent ${i + 1}`, ...overrides });
+    insertGame({ opponent_name: `Extra Game ${i + 1}`, ...overrides });
   }
 }
+
+// --- UI helper ---
 
 async function addGame(page: Page, opponentName: string) {
   await page.goto('/blood-bowl/add');
@@ -70,6 +76,8 @@ async function addGame(page: Page, opponentName: string) {
   await expect(page).toHaveURL('/blood-bowl/');
 }
 
+// --- CRUD ---
+
 test('add a game', async ({ page }) => {
   const name = `Add-Test-${Date.now()}`;
   await addGame(page, name);
@@ -77,7 +85,7 @@ test('add a game', async ({ page }) => {
 });
 
 test('edit a game', async ({ page }) => {
-  const name = `Edit-Test-${Date.now()}`;
+  const name       = `Edit-Test-${Date.now()}`;
   const editedName = `Edited-${Date.now()}`;
   await addGame(page, name);
 
@@ -112,11 +120,8 @@ test('delete a game', async ({ page }) => {
 // --- W/D/L ordering ---
 
 test('stats card shows results in W/D/L order', async ({ page }) => {
-  insertGame({ result: 'W' });
-  insertGame({ result: 'D' });
-  insertGame({ result: 'L' });
+  // Seed contains Seed W Game, Seed D Game, Seed L Game
   await page.goto('/blood-bowl');
-
   const text = await page.locator('.overall').textContent() ?? '';
   expect(text.indexOf('W')).toBeLessThan(text.indexOf('D'));
   expect(text.indexOf('D')).toBeLessThan(text.indexOf('L'));
@@ -125,116 +130,92 @@ test('stats card shows results in W/D/L order', async ({ page }) => {
 // --- Add game link position ---
 
 test('add game link appears above the game table', async ({ page }) => {
-  insertGame();
   await page.goto('/blood-bowl');
-
   const linkY  = (await page.getByRole('link', { name: '+ Add game' }).boundingBox())!.y;
   const tableY = (await page.getByRole('table', { name: 'Games' }).boundingBox())!.y;
   expect(linkY).toBeLessThan(tableY);
 });
 
-// --- Pagination ---
+// --- Pagination (requires >10 games; insertGames adds on top of the 8 seeded) ---
 
 test('shows 10 games per page', async ({ page }) => {
-  insertGames(11);
+  insertGames(3); // 8 seeded + 3 = 11 total
   await page.goto('/blood-bowl');
-
   const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
   await expect(rows).toHaveCount(11); // 1 header + 10 data rows
 });
 
 test('next link navigates to page 2', async ({ page }) => {
-  insertGames(11);
+  insertGames(3); // 11 total → page 2 has 1 game
   await page.goto('/blood-bowl');
-
   await page.getByRole('link', { name: /Next/ }).click();
   await expect(page).toHaveURL(/page=2/);
-
   const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
-  await expect(rows).toHaveCount(2); // 1 header + 1 remaining game
+  await expect(rows).toHaveCount(2); // 1 header + 1 game
 });
 
 test('prev link navigates back to page 1', async ({ page }) => {
-  insertGames(11);
+  insertGames(3); // 11 total
   await page.goto('/blood-bowl?page=2');
-
   await page.getByRole('link', { name: /Prev/ }).click();
   await expect(page).toHaveURL(/page=1/);
-
   const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
-  await expect(rows).toHaveCount(11);
+  await expect(rows).toHaveCount(11); // 1 header + 10 data rows
 });
 
 test('prev is disabled on page 1', async ({ page }) => {
-  insertGame();
   await page.goto('/blood-bowl');
-
   await expect(page.getByRole('link', { name: /Prev/ })).not.toBeVisible();
   await expect(page.locator('.disabled', { hasText: 'Prev' })).toBeVisible();
 });
 
 test('next is disabled on the last page', async ({ page }) => {
-  insertGame();
+  // 8 seeded games fit on one page
   await page.goto('/blood-bowl');
-
   await expect(page.getByRole('link', { name: /Next/ })).not.toBeVisible();
   await expect(page.locator('.disabled', { hasText: 'Next' })).toBeVisible();
 });
 
-// --- Filters ---
+// --- Filters (use seed data directly) ---
 
 test('platform filter narrows results', async ({ page }) => {
-  insertGame({ opponent_name: 'BB3 Game',    platform: 'Blood Bowl 3', format: 'league' });
-  insertGame({ opponent_name: 'Fumbbl Game', platform: 'Fumbbl',       format: 'league' });
   await page.goto('/blood-bowl?platform=Blood+Bowl+3');
-
   const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('BB3 Game');
+  await expect(table).toContainText('Seed W Game');
   await expect(table).not.toContainText('Fumbbl Game');
 });
 
 test('format filter narrows results', async ({ page }) => {
-  insertGame({ opponent_name: 'League Game', format: 'league'  });
-  insertGame({ opponent_name: 'Ladder Game', format: 'ladder'  });
   await page.goto('/blood-bowl?format=league');
-
   const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('League Game');
+  await expect(table).toContainText('Seed W Game');
   await expect(table).not.toContainText('Ladder Game');
 });
 
 test('my race filter narrows results', async ({ page }) => {
-  insertGame({ opponent_name: 'Orc Game',   my_race: 'Orc'   });
-  insertGame({ opponent_name: 'Dwarf Game', my_race: 'Dwarf' });
   await page.goto('/blood-bowl?my_race=Orc');
-
   const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('Orc Game');
+  await expect(table).toContainText('Seed W Game');
   await expect(table).not.toContainText('Dwarf Game');
 });
 
 test('opponent race filter narrows results', async ({ page }) => {
-  insertGame({ opponent_name: 'vs Human', opponent_race: 'Human' });
-  insertGame({ opponent_name: 'vs Skaven', opponent_race: 'Skaven' });
   await page.goto('/blood-bowl?opponent_race=Human');
-
   const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('vs Human');
-  await expect(table).not.toContainText('vs Skaven');
+  await expect(table).toContainText('Seed W Game');
+  await expect(table).not.toContainText('Skaven Game');
 });
 
 test('clear link resets all filters', async ({ page }) => {
-  insertGame({ opponent_name: 'BB3 Game', platform: 'Blood Bowl 3' });
   await page.goto('/blood-bowl?platform=Blood+Bowl+3');
-
   await page.getByRole('link', { name: 'Clear' }).click();
   await expect(page).toHaveURL('/blood-bowl');
 });
 
 test('filters are preserved in pagination links', async ({ page }) => {
-  insertGames(11, { platform: 'Blood Bowl 3', format: 'league' });
+  // 6 seeded BB3 games + 5 more = 11, triggering a second page
+  insertGames(5, { platform: 'Blood Bowl 3', format: 'league' });
   await page.goto('/blood-bowl?platform=Blood+Bowl+3');
-
   const nextHref = await page.getByRole('link', { name: /Next/ }).getAttribute('href');
   expect(nextHref).toContain('platform=Blood+Bowl+3');
 });
@@ -242,25 +223,16 @@ test('filters are preserved in pagination links', async ({ page }) => {
 // --- Format options scoped to platform ---
 
 test('selecting a platform updates format options to match', async ({ page }) => {
-  insertGame({ platform: 'tabletop', format: 'tournament' });
   await page.goto('/blood-bowl');
-
   await page.locator('#platform-select').selectOption('tabletop');
-
-  const formatOptions = page.locator('#format-select option');
-  const labels = await formatOptions.allTextContents();
+  const labels = await page.locator('#format-select option').allTextContents();
   expect(labels).toContain('tournament');
-  // league exists for BB3/Fumbbl but not tabletop
-  expect(labels).not.toContain('league');
+  expect(labels).not.toContain('ladder'); // ladder is BB3/Fumbbl only
 });
 
-test('format dropdown shows all options when no platform selected', async ({ page }) => {
-  insertGame({ platform: 'Blood Bowl 3', format: 'league'      });
-  insertGame({ platform: 'tabletop',     format: 'tournament'  });
+test('format dropdown shows all options when no platform is selected', async ({ page }) => {
   await page.goto('/blood-bowl');
-
-  const formatOptions = page.locator('#format-select option');
-  const labels = await formatOptions.allTextContents();
+  const labels = await page.locator('#format-select option').allTextContents();
   expect(labels).toContain('league');
   expect(labels).toContain('tournament');
 });

--- a/tests/blood-bowl.spec.ts
+++ b/tests/blood-bowl.spec.ts
@@ -130,42 +130,54 @@ test('next is disabled on the last page', async ({ page }) => {
 // --- Filters (use seed data directly) ---
 
 test('platform filter narrows results', async ({ page }) => {
-  await page.goto('/blood-bowl?platform=Blood+Bowl+3');
+  await page.goto('/blood-bowl');
+  await page.locator('#platform-select').selectOption('Blood Bowl 3');
+  await page.getByRole('button', { name: 'Filter' }).click();
   const table = page.getByRole('table', { name: 'Games' });
   await expect(table).toContainText('BB3 Extra 5');
   await expect(table).not.toContainText('Fumbbl Game');
 });
 
 test('format filter narrows results', async ({ page }) => {
-  await page.goto('/blood-bowl?format=league');
+  await page.goto('/blood-bowl');
+  await page.locator('#format-select').selectOption('league');
+  await page.getByRole('button', { name: 'Filter' }).click();
   const table = page.getByRole('table', { name: 'Games' });
   await expect(table).toContainText('BB3 Extra 5');
   await expect(table).not.toContainText('Ladder Game');
 });
 
 test('my race filter narrows results', async ({ page }) => {
-  await page.goto('/blood-bowl?my_race=Orc');
+  await page.goto('/blood-bowl');
+  await page.locator('select[name="my_race"]').selectOption('Orc');
+  await page.getByRole('button', { name: 'Filter' }).click();
   const table = page.getByRole('table', { name: 'Games' });
   await expect(table).toContainText('BB3 Extra 5');
   await expect(table).not.toContainText('Dwarf Game');
 });
 
 test('opponent race filter narrows results', async ({ page }) => {
-  await page.goto('/blood-bowl?opponent_race=Human');
+  await page.goto('/blood-bowl');
+  await page.locator('select[name="opponent_race"]').selectOption('Human');
+  await page.getByRole('button', { name: 'Filter' }).click();
   const table = page.getByRole('table', { name: 'Games' });
   await expect(table).toContainText('BB3 Extra 5');
   await expect(table).not.toContainText('Skaven Game');
 });
 
 test('clear link resets all filters', async ({ page }) => {
-  await page.goto('/blood-bowl?platform=Blood+Bowl+3');
+  await page.goto('/blood-bowl');
+  await page.locator('#platform-select').selectOption('Blood Bowl 3');
+  await page.getByRole('button', { name: 'Filter' }).click();
   await page.getByRole('link', { name: 'Clear' }).click();
   await expect(page).toHaveURL('/blood-bowl');
 });
 
 test('filters are preserved in pagination links', async ({ page }) => {
   // 11 seeded BB3 games trigger a second page when filtering by platform
-  await page.goto('/blood-bowl?platform=Blood+Bowl+3');
+  await page.goto('/blood-bowl');
+  await page.locator('#platform-select').selectOption('Blood Bowl 3');
+  await page.getByRole('button', { name: 'Filter' }).click();
   const nextHref = await page.getByRole('link', { name: /Next/ }).getAttribute('href');
   expect(nextHref).toContain('platform=Blood+Bowl+3');
 });

--- a/tests/blood-bowl.spec.ts
+++ b/tests/blood-bowl.spec.ts
@@ -131,7 +131,7 @@ test('next is disabled on the last page', async ({ page }) => {
 
 test('platform filter narrows results', async ({ page }) => {
   await page.goto('/blood-bowl');
-  await page.locator('#platform-select').selectOption('Blood Bowl 3');
+  await page.getByLabel('Platform').selectOption('Blood Bowl 3');
   await page.getByRole('button', { name: 'Filter' }).click();
   const table = page.getByRole('table', { name: 'Games' });
   await expect(table).toContainText('BB3 Extra 5');
@@ -140,7 +140,7 @@ test('platform filter narrows results', async ({ page }) => {
 
 test('format filter narrows results', async ({ page }) => {
   await page.goto('/blood-bowl');
-  await page.locator('#format-select').selectOption('league');
+  await page.getByLabel('Format').selectOption('league');
   await page.getByRole('button', { name: 'Filter' }).click();
   const table = page.getByRole('table', { name: 'Games' });
   await expect(table).toContainText('BB3 Extra 5');
@@ -149,7 +149,7 @@ test('format filter narrows results', async ({ page }) => {
 
 test('my race filter narrows results', async ({ page }) => {
   await page.goto('/blood-bowl');
-  await page.locator('select[name="my_race"]').selectOption('Orc');
+  await page.getByLabel('My Race').selectOption('Orc');
   await page.getByRole('button', { name: 'Filter' }).click();
   const table = page.getByRole('table', { name: 'Games' });
   await expect(table).toContainText('BB3 Extra 5');
@@ -158,7 +158,7 @@ test('my race filter narrows results', async ({ page }) => {
 
 test('opponent race filter narrows results', async ({ page }) => {
   await page.goto('/blood-bowl');
-  await page.locator('select[name="opponent_race"]').selectOption('Human');
+  await page.getByLabel('Opponent Race').selectOption('Human');
   await page.getByRole('button', { name: 'Filter' }).click();
   const table = page.getByRole('table', { name: 'Games' });
   await expect(table).toContainText('BB3 Extra 5');
@@ -167,7 +167,7 @@ test('opponent race filter narrows results', async ({ page }) => {
 
 test('clear link resets all filters', async ({ page }) => {
   await page.goto('/blood-bowl');
-  await page.locator('#platform-select').selectOption('Blood Bowl 3');
+  await page.getByLabel('Platform').selectOption('Blood Bowl 3');
   await page.getByRole('button', { name: 'Filter' }).click();
   await page.getByRole('link', { name: 'Clear' }).click();
   await expect(page).toHaveURL('/blood-bowl');
@@ -176,7 +176,7 @@ test('clear link resets all filters', async ({ page }) => {
 test('filters are preserved in pagination links', async ({ page }) => {
   // 11 seeded BB3 games trigger a second page when filtering by platform
   await page.goto('/blood-bowl');
-  await page.locator('#platform-select').selectOption('Blood Bowl 3');
+  await page.getByLabel('Platform').selectOption('Blood Bowl 3');
   await page.getByRole('button', { name: 'Filter' }).click();
   const nextHref = await page.getByRole('link', { name: /Next/ }).getAttribute('href');
   expect(nextHref).toContain('platform=Blood+Bowl+3');
@@ -186,15 +186,15 @@ test('filters are preserved in pagination links', async ({ page }) => {
 
 test('selecting a platform updates format options to match', async ({ page }) => {
   await page.goto('/blood-bowl');
-  await page.locator('#platform-select').selectOption('tabletop');
-  const labels = await page.locator('#format-select option').allTextContents();
+  await page.getByLabel('Platform').selectOption('tabletop');
+  const labels = await page.getByLabel('Format').locator('option').allTextContents();
   expect(labels).toContain('tournament');
   expect(labels).not.toContain('ladder'); // ladder is BB3/Fumbbl only
 });
 
 test('format dropdown shows all options when no platform is selected', async ({ page }) => {
   await page.goto('/blood-bowl');
-  const labels = await page.locator('#format-select option').allTextContents();
+  const labels = await page.getByLabel('Format').locator('option').allTextContents();
   expect(labels).toContain('league');
   expect(labels).toContain('tournament');
 });

--- a/tests/blood-bowl.spec.ts
+++ b/tests/blood-bowl.spec.ts
@@ -13,51 +13,6 @@ test.beforeEach(() => {
   execSync('node scripts/seed-test.js', { env: { ...process.env, DB_PATH: TEST_DB } });
 });
 
-// --- Helpers for tests that need data beyond the seed ---
-
-type GameOverrides = Partial<{
-  opponent_name: string;
-  my_race: string;
-  opponent_race: string;
-  result: 'W' | 'L' | 'D';
-  score_for: number;
-  score_against: number;
-  date: string;
-  platform: string;
-  format: string;
-}>;
-
-function insertGame(overrides: GameOverrides = {}) {
-  const opts = {
-    opponent_name: 'Test Opponent',
-    my_race: 'Orc',
-    opponent_race: 'Human',
-    result: 'W' as const,
-    score_for: 2,
-    score_against: 1,
-    date: '2026-01-01',
-    platform: 'Blood Bowl 3',
-    format: 'league',
-    ...overrides,
-  };
-  const db = new Database(TEST_DB);
-  const myRaceId   = (db.prepare('SELECT id FROM teams     WHERE name = ?').get(opts.my_race)   as { id: number }).id;
-  const oppRaceId  = (db.prepare('SELECT id FROM teams     WHERE name = ?').get(opts.opponent_race) as { id: number }).id;
-  const platformId = (db.prepare('SELECT id FROM platforms WHERE name = ?').get(opts.platform)  as { id: number }).id;
-  const formatId   = (db.prepare('SELECT id FROM formats   WHERE name = ? AND platform_id = ?').get(opts.format, platformId) as { id: number }).id;
-  db.prepare(`
-    INSERT INTO games (opponent_name, my_race_id, opponent_race_id, result, score_for, score_against, date, platform_id, format_id, notes)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
-  `).run(opts.opponent_name, myRaceId, oppRaceId, opts.result, opts.score_for, opts.score_against, opts.date, platformId, formatId);
-  db.close();
-}
-
-function insertGames(count: number, overrides: GameOverrides = {}) {
-  for (let i = 0; i < count; i++) {
-    insertGame({ opponent_name: `Extra Game ${i + 1}`, ...overrides });
-  }
-}
-
 // --- UI helper ---
 
 async function addGame(page: Page, opponentName: string) {
@@ -136,26 +91,23 @@ test('add game link appears above the game table', async ({ page }) => {
   expect(linkY).toBeLessThan(tableY);
 });
 
-// --- Pagination (requires >10 games; insertGames adds on top of the 8 seeded) ---
+// --- Pagination (13 seeded games: 10 on page 1, 3 on page 2) ---
 
 test('shows 10 games per page', async ({ page }) => {
-  insertGames(3); // 8 seeded + 3 = 11 total
   await page.goto('/blood-bowl');
   const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
   await expect(rows).toHaveCount(11); // 1 header + 10 data rows
 });
 
 test('next link navigates to page 2', async ({ page }) => {
-  insertGames(3); // 11 total → page 2 has 1 game
   await page.goto('/blood-bowl');
   await page.getByRole('link', { name: /Next/ }).click();
   await expect(page).toHaveURL(/page=2/);
   const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
-  await expect(rows).toHaveCount(2); // 1 header + 1 game
+  await expect(rows).toHaveCount(4); // 1 header + 3 games
 });
 
 test('prev link navigates back to page 1', async ({ page }) => {
-  insertGames(3); // 11 total
   await page.goto('/blood-bowl?page=2');
   await page.getByRole('link', { name: /Prev/ }).click();
   await expect(page).toHaveURL(/page=1/);
@@ -170,8 +122,7 @@ test('prev is disabled on page 1', async ({ page }) => {
 });
 
 test('next is disabled on the last page', async ({ page }) => {
-  // 8 seeded games fit on one page
-  await page.goto('/blood-bowl');
+  await page.goto('/blood-bowl?page=2');
   await expect(page.getByRole('link', { name: /Next/ })).not.toBeVisible();
   await expect(page.locator('.disabled', { hasText: 'Next' })).toBeVisible();
 });
@@ -181,28 +132,28 @@ test('next is disabled on the last page', async ({ page }) => {
 test('platform filter narrows results', async ({ page }) => {
   await page.goto('/blood-bowl?platform=Blood+Bowl+3');
   const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('Seed W Game');
+  await expect(table).toContainText('BB3 Extra 5');
   await expect(table).not.toContainText('Fumbbl Game');
 });
 
 test('format filter narrows results', async ({ page }) => {
   await page.goto('/blood-bowl?format=league');
   const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('Seed W Game');
+  await expect(table).toContainText('BB3 Extra 5');
   await expect(table).not.toContainText('Ladder Game');
 });
 
 test('my race filter narrows results', async ({ page }) => {
   await page.goto('/blood-bowl?my_race=Orc');
   const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('Seed W Game');
+  await expect(table).toContainText('BB3 Extra 5');
   await expect(table).not.toContainText('Dwarf Game');
 });
 
 test('opponent race filter narrows results', async ({ page }) => {
   await page.goto('/blood-bowl?opponent_race=Human');
   const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('Seed W Game');
+  await expect(table).toContainText('BB3 Extra 5');
   await expect(table).not.toContainText('Skaven Game');
 });
 
@@ -213,8 +164,7 @@ test('clear link resets all filters', async ({ page }) => {
 });
 
 test('filters are preserved in pagination links', async ({ page }) => {
-  // 6 seeded BB3 games + 5 more = 11, triggering a second page
-  insertGames(5, { platform: 'Blood Bowl 3', format: 'league' });
+  // 11 seeded BB3 games trigger a second page when filtering by platform
   await page.goto('/blood-bowl?platform=Blood+Bowl+3');
   const nextHref = await page.getByRole('link', { name: /Next/ }).getAttribute('href');
   expect(nextHref).toContain('platform=Blood+Bowl+3');

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -4,13 +4,12 @@ import fs from 'fs';
 
 const TEST_DB = path.join(process.cwd(), 'data', 'test.db');
 
-export default function globalSetup() {
-  // Always start fresh
-  if (fs.existsSync(TEST_DB)) {
-    fs.unlinkSync(TEST_DB);
-  }
+function runSeed(cmd: string) {
+  execSync(cmd, { env: { ...process.env, DB_PATH: TEST_DB } });
+}
 
-  execSync('npx tsx src/lib/seed.ts', {
-    env: { ...process.env, DB_PATH: TEST_DB },
-  });
+export default function globalSetup() {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  runSeed('npx tsx src/lib/seed.ts');      // schema + reference data
+  runSeed('node scripts/seed-test.js');    // known test games
 }


### PR DESCRIPTION
## Summary

- Reorder results display from W/L/D → **W/D/L** in the overall record and per-race breakdown table
- Add **pagination** to the game table — 10 records per page, navigated via `?page=` query param with Prev/Next links
- Add **filters** for platform, format, my race, and opponent race — dropdowns filter games via query params; stats reflect the filtered set; pagination preserves active filters; a Clear link resets all filters
- Move **Add Game link** above the game table
- Add `scripts/seed-dev.js` to populate the local dev database with 110 random games

## Test plan

- [ ] Visit `/blood-bowl` and confirm the overall record and race breakdown table show W / D / L order
- [ ] Confirm the game table shows 10 rows per page with working Prev / Next links
- [ ] Confirm page clamps correctly at page 1 and the last page
- [ ] Filter by platform, format, my race, and opponent race — confirm table and stats update
- [ ] Confirm pagination preserves all active filters
- [ ] Confirm the Clear link resets all filters
- [ ] Confirm the Add Game link appears above the table
- [ ] Run `node scripts/seed-dev.js` and confirm 110 games are inserted into the local DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)