### PR TITLE
Add oxfmt for JS/TS formatting

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,16 @@
+name: Format check
+
+on:
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run format:check

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Despite the repo name, this is an **Astro 5** static blog (migrated from Elevent
 **Styling**: Single global CSS file at `src/styles/main.css` using CSS variables. No preprocessor or CSS-in-JS.
 
 **TypeScript path aliases** (configured in `tsconfig.json`):
+
 - `@components` → `src/components/`
 - `@layouts` → `src/layouts/`
 - `@styles` → `src/styles/`

--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ Personal blog built with [Astro 5](https://astro.build), deployed on [Fly.io](ht
 
 ## Commands
 
-| Command            | Action                                      |
-|:------------------ |:------------------------------------------- |
-| `npm install`      | Install dependencies                        |
-| `npm run dev`      | Start dev server at `localhost:4321`        |
-| `npm run build`    | Build production site to `./dist/`          |
-| `npm run preview`  | Preview production build locally            |
-| `npm run check`    | Run Astro type checking                     |
-| `npm run backup`   | Back up the production SQLite database      |
-| `npm run deploy`   | Back up the database, then deploy to Fly.io |
+| Command           | Action                                      |
+| :---------------- | :------------------------------------------ |
+| `npm install`     | Install dependencies                        |
+| `npm run dev`     | Start dev server at `localhost:4321`        |
+| `npm run build`   | Build production site to `./dist/`          |
+| `npm run preview` | Preview production build locally            |
+| `npm run check`   | Run Astro type checking                     |
+| `npm run backup`  | Back up the production SQLite database      |
+| `npm run deploy`  | Back up the database, then deploy to Fly.io |
 
 ## Adding a Post
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,19 +1,19 @@
-import { defineConfig } from 'astro/config';
-import node from '@astrojs/node';
+import { defineConfig } from "astro/config";
+import node from "@astrojs/node";
 
 export default defineConfig({
-  site: 'https://shealeslein.com',
+  site: "https://shealeslein.com",
   build: {
-    format: 'directory'
+    format: "directory",
   },
-  output: 'static',
-  adapter: node({ mode: 'standalone' }),
+  output: "static",
+  adapter: node({ mode: "standalone" }),
   security: { checkOrigin: false },
   markdown: {
     shikiConfig: {
-      theme: 'github-light',
-      wrap: true
-    }
+      theme: "github-light",
+      wrap: true,
+    },
   },
-  integrations: []
+  integrations: [],
 });

--- a/blood-bowl-plan.md
+++ b/blood-bowl-plan.md
@@ -37,10 +37,13 @@ CREATE TABLE IF NOT EXISTS games (
 ## New Files
 
 ### `src/lib/db.ts`
+
 Singleton that opens/creates the SQLite database and runs `CREATE TABLE IF NOT EXISTS` on first connect. Exported as `getDb()`.
 
 ### `src/pages/blood-bowl/index.astro`
+
 SSR page (`export const prerender = false`). Queries all games, computes:
+
 - Overall W/L/D totals
 - W/L/D breakdown by opponent race
 - Full results table sorted by date descending
@@ -48,14 +51,17 @@ SSR page (`export const prerender = false`). Queries all games, computes:
 Uses `BaseLayout` with `title="Blood Bowl"`.
 
 ### `src/pages/blood-bowl/add.astro`
+
 SSR page with a form to add a new game. On GET: renders the form. On POST: inserts the row and redirects to `/blood-bowl/`.
 
 Protected by a `BLOOD_BOWL_KEY` environment variable — the form requires a password field that must match the env var before the insert runs. If wrong, re-renders with an error.
 
 ### `src/components/GameTable.astro`
+
 Renders the results table (date, opponent, race, result, score, league, notes).
 
 ### `src/components/StatsCard.astro`
+
 Renders a W/L/D summary card — overall and per-race breakdown.
 
 ---
@@ -63,9 +69,11 @@ Renders a W/L/D summary card — overall and per-race breakdown.
 ## Modified Files
 
 ### `astro.config.mjs`
+
 Change `output: 'static'` to `output: 'hybrid'` to allow SSR pages alongside static ones.
 
 ### `src/components/Header.astro`
+
 Add a `/blood-bowl/` nav link alongside the existing `/posts` and `/about` links.
 
 ---
@@ -73,6 +81,7 @@ Add a `/blood-bowl/` nav link alongside the existing `/posts` and `/about` links
 ## Environment Variable
 
 Add `BLOOD_BOWL_KEY` as a Fly.io secret:
+
 ```bash
 fly secrets set BLOOD_BOWL_KEY=<your-password>
 ```
@@ -83,10 +92,10 @@ Used only server-side to gate the add-game form. Never exposed to the client.
 
 ## Page Routes
 
-| Route | Type | Purpose |
-|---|---|---|
-| `/blood-bowl/` | SSR | Stats summary + full results table |
-| `/blood-bowl/add` | SSR | Form to add a new game |
+| Route             | Type | Purpose                            |
+| ----------------- | ---- | ---------------------------------- |
+| `/blood-bowl/`    | SSR  | Stats summary + full results table |
+| `/blood-bowl/add` | SSR  | Form to add a new game             |
 
 ---
 

--- a/fly.toml
+++ b/fly.toml
@@ -4,21 +4,21 @@ primary_region = 'iad'
 [build]
 
 [env]
-  PORT = "8080"
-  NODE_ENV = "production"
+PORT = "8080"
+NODE_ENV = "production"
 
 [http_service]
-  internal_port = 8080
-  force_https = true
-  auto_stop_machines = "stop"
-  auto_start_machines = true
-  min_machines_running = 0
+internal_port = 8080
+force_https = true
+auto_stop_machines = "stop"
+auto_start_machines = true
+min_machines_running = 0
 
 [[vm]]
-  memory = "256mb"
-  cpu_kind = "shared"
-  cpus = 1
+memory = "256mb"
+cpu_kind = "shared"
+cpus = 1
 
 [mounts]
-  source = "sqlite_data"
-  destination = "/data"
+source = "sqlite_data"
+destination = "/data"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "astro": "^6.3.7",
-        "dotenv": "^17.3.1"
+        "dotenv": "^17.3.1",
+        "oxfmt": "^0.52.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1093,6 +1094,329 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.52.0.tgz",
+      "integrity": "sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.52.0.tgz",
+      "integrity": "sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.52.0.tgz",
+      "integrity": "sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.52.0.tgz",
+      "integrity": "sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.52.0.tgz",
+      "integrity": "sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.52.0.tgz",
+      "integrity": "sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.52.0.tgz",
+      "integrity": "sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.52.0.tgz",
+      "integrity": "sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.52.0.tgz",
+      "integrity": "sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.52.0.tgz",
+      "integrity": "sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.52.0.tgz",
+      "integrity": "sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.52.0.tgz",
+      "integrity": "sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.52.0.tgz",
+      "integrity": "sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.52.0.tgz",
+      "integrity": "sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.52.0.tgz",
+      "integrity": "sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.52.0.tgz",
+      "integrity": "sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.52.0.tgz",
+      "integrity": "sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.52.0.tgz",
+      "integrity": "sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.52.0.tgz",
+      "integrity": "sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
@@ -3997,6 +4321,58 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/oxfmt": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.52.0.tgz",
+      "integrity": "sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.52.0",
+        "@oxfmt/binding-android-arm64": "0.52.0",
+        "@oxfmt/binding-darwin-arm64": "0.52.0",
+        "@oxfmt/binding-darwin-x64": "0.52.0",
+        "@oxfmt/binding-freebsd-x64": "0.52.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.52.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.52.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.52.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.52.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.52.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.52.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.52.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.52.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.52.0",
+        "@oxfmt/binding-linux-x64-musl": "0.52.0",
+        "@oxfmt/binding-openharmony-arm64": "0.52.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.52.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.52.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.52.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-limit": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
@@ -4931,6 +5307,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -11,17 +11,20 @@
     "check": "astro check",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
+    "format": "oxfmt",
+    "format:check": "oxfmt --check",
     "backup": "bash scripts/backup.sh",
     "deploy": "bash scripts/deploy.sh"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.58.2",
-    "astro": "^6.3.7",
-    "dotenv": "^17.3.1"
   },
   "dependencies": {
     "@astrojs/node": "^10.1.1",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.6.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2",
+    "astro": "^6.3.7",
+    "dotenv": "^17.3.1",
+    "oxfmt": "^0.52.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,15 +1,15 @@
-import { defineConfig } from '@playwright/test';
-import path from 'path';
-import { config } from 'dotenv';
+import { defineConfig } from "@playwright/test";
+import path from "path";
+import { config } from "dotenv";
 
 config(); // load .env
 
 const TEST_PORT = 4399;
-const TEST_DB = path.join(process.cwd(), 'data', 'test.db');
+const TEST_DB = path.join(process.cwd(), "data", "test.db");
 
 export default defineConfig({
-  testDir: './tests',
-  globalSetup: './tests/global-setup.ts',
+  testDir: "./tests",
+  globalSetup: "./tests/global-setup.ts",
   use: {
     baseURL: `http://localhost:${TEST_PORT}`,
   },
@@ -19,7 +19,7 @@ export default defineConfig({
     reuseExistingServer: false,
     env: {
       DB_PATH: TEST_DB,
-      BLOOD_BOWL_KEY: process.env.BLOOD_BOWL_KEY ?? '',
+      BLOOD_BOWL_KEY: process.env.BLOOD_BOWL_KEY ?? "",
     },
   },
 });

--- a/scripts/seed-dev.js
+++ b/scripts/seed-dev.js
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
-import Database from 'better-sqlite3';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import Database from "better-sqlite3";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const DB_PATH = path.join(__dirname, '../data/bloodbowl.db');
+const DB_PATH = path.join(__dirname, "../data/bloodbowl.db");
 
 const db = new Database(DB_PATH);
-db.pragma('journal_mode = WAL');
+db.pragma("journal_mode = WAL");
 
-const teams    = db.prepare('SELECT id, name FROM teams').all();
-const platforms = db.prepare('SELECT id, name FROM platforms').all();
-const formats   = db.prepare('SELECT id, name, platform_id FROM formats').all();
+const teams = db.prepare("SELECT id, name FROM teams").all();
+const platforms = db.prepare("SELECT id, name FROM platforms").all();
+const formats = db.prepare("SELECT id, name, platform_id FROM formats").all();
 
 const formatsByPlatform = new Map();
 for (const f of formats) {
@@ -20,20 +20,36 @@ for (const f of formats) {
 }
 
 const opponents = [
-  'Grimbold Ironside', 'Coach McMurphy', 'The Legendary Zug', 'Darkside Cowboys',
-  'Varag Ghoul-Chewer', 'Morg N Thorg', 'Griff Oberwald', 'Puggy Baconbreath',
-  'Helmut Wulf', 'Bertha Bigfist', 'Ramtut III', 'Mummy McGee',
-  'Nobbla Blackwart', 'Deeproot Strongbranch', 'Rashnak Backstabber', 'Wilhelm Chaney',
+  "Grimbold Ironside",
+  "Coach McMurphy",
+  "The Legendary Zug",
+  "Darkside Cowboys",
+  "Varag Ghoul-Chewer",
+  "Morg N Thorg",
+  "Griff Oberwald",
+  "Puggy Baconbreath",
+  "Helmut Wulf",
+  "Bertha Bigfist",
+  "Ramtut III",
+  "Mummy McGee",
+  "Nobbla Blackwart",
+  "Deeproot Strongbranch",
+  "Rashnak Backstabber",
+  "Wilhelm Chaney",
 ];
 
-const results = ['W', 'W', 'W', 'D', 'L', 'L'];
+const results = ["W", "W", "W", "D", "L", "L"];
 
-function rand(arr) { return arr[Math.floor(Math.random() * arr.length)]; }
-function randInt(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
+function rand(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+function randInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
 
 function randDate() {
-  const start = new Date('2023-01-01');
-  const end   = new Date('2026-05-24');
+  const start = new Date("2023-01-01");
+  const end = new Date("2026-05-24");
   const d = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
   return d.toISOString().slice(0, 10);
 }
@@ -46,12 +62,12 @@ const insert = db.prepare(`
 
 const insertMany = db.transaction(() => {
   for (let i = 0; i < 110; i++) {
-    const myRace       = rand(teams);
+    const myRace = rand(teams);
     const opponentRace = rand(teams);
-    const platform     = rand(platforms);
-    const format       = rand(formatsByPlatform.get(platform.id));
-    const result       = rand(results);
-    const scoreFor     = randInt(0, 5);
+    const platform = rand(platforms);
+    const format = rand(formatsByPlatform.get(platform.id));
+    const result = rand(results);
+    const scoreFor = randInt(0, 5);
     const scoreAgainst = randInt(0, 5);
 
     insert.run(
@@ -70,4 +86,4 @@ const insertMany = db.transaction(() => {
 });
 
 insertMany();
-console.log('Inserted 110 random games into', DB_PATH);
+console.log("Inserted 110 random games into", DB_PATH);

--- a/scripts/seed-test.js
+++ b/scripts/seed-test.js
@@ -2,25 +2,26 @@
 // Inserts a fixed set of named test games. Requires the DB to already be
 // initialized (schema + reference data). Run via:
 //   DB_PATH=data/test.db node scripts/seed-test.js
-import Database from 'better-sqlite3';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import Database from "better-sqlite3";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const DB_PATH = process.env.DB_PATH || path.join(__dirname, '../data/test.db');
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, "../data/test.db");
 
 const db = new Database(DB_PATH);
 
-const id   = (table, col, val) => db.prepare(`SELECT id FROM ${table} WHERE ${col} = ?`).get(val).id;
-const fmt  = (name, pid)       => db.prepare('SELECT id FROM formats WHERE name = ? AND platform_id = ?').get(name, pid).id;
+const id = (table, col, val) => db.prepare(`SELECT id FROM ${table} WHERE ${col} = ?`).get(val).id;
+const fmt = (name, pid) =>
+  db.prepare("SELECT id FROM formats WHERE name = ? AND platform_id = ?").get(name, pid).id;
 
-const orc      = id('teams',     'name', 'Orc');
-const human    = id('teams',     'name', 'Human');
-const dwarf    = id('teams',     'name', 'Dwarf');
-const skaven   = id('teams',     'name', 'Skaven');
-const bb3      = id('platforms', 'name', 'Blood Bowl 3');
-const fumbbl   = id('platforms', 'name', 'Fumbbl');
-const tabletop = id('platforms', 'name', 'tabletop');
+const orc = id("teams", "name", "Orc");
+const human = id("teams", "name", "Human");
+const dwarf = id("teams", "name", "Dwarf");
+const skaven = id("teams", "name", "Skaven");
+const bb3 = id("platforms", "name", "Blood Bowl 3");
+const fumbbl = id("platforms", "name", "Fumbbl");
+const tabletop = id("platforms", "name", "tabletop");
 
 const ins = db.prepare(`
   INSERT INTO games
@@ -30,21 +31,31 @@ const ins = db.prepare(`
 `);
 
 db.transaction(() => {
-  ins.run('Seed W Game',    orc,   human,  'W', 2, 1, '2024-01-01', bb3,      fmt('league',     bb3));
-  ins.run('Seed D Game',    orc,   human,  'D', 0, 0, '2024-01-02', bb3,      fmt('league',     bb3));
-  ins.run('Seed L Game',    orc,   human,  'L', 1, 2, '2024-01-03', bb3,      fmt('league',     bb3));
-  ins.run('Fumbbl Game',    orc,   human,  'W', 2, 1, '2024-01-04', fumbbl,   fmt('league',     fumbbl));
-  ins.run('Ladder Game',    orc,   human,  'W', 3, 0, '2024-01-05', bb3,      fmt('ladder',     bb3));
-  ins.run('Dwarf Game',     dwarf, human,  'W', 1, 0, '2024-01-06', bb3,      fmt('league',     bb3));
-  ins.run('Skaven Game',    orc,   skaven, 'W', 2, 1, '2024-01-07', bb3,      fmt('league',     bb3));
-  ins.run('Tabletop Game',  orc,   human,  'W', 2, 0, '2024-01-08', tabletop, fmt('tournament', tabletop));
+  ins.run("Seed W Game", orc, human, "W", 2, 1, "2024-01-01", bb3, fmt("league", bb3));
+  ins.run("Seed D Game", orc, human, "D", 0, 0, "2024-01-02", bb3, fmt("league", bb3));
+  ins.run("Seed L Game", orc, human, "L", 1, 2, "2024-01-03", bb3, fmt("league", bb3));
+  ins.run("Fumbbl Game", orc, human, "W", 2, 1, "2024-01-04", fumbbl, fmt("league", fumbbl));
+  ins.run("Ladder Game", orc, human, "W", 3, 0, "2024-01-05", bb3, fmt("ladder", bb3));
+  ins.run("Dwarf Game", dwarf, human, "W", 1, 0, "2024-01-06", bb3, fmt("league", bb3));
+  ins.run("Skaven Game", orc, skaven, "W", 2, 1, "2024-01-07", bb3, fmt("league", bb3));
+  ins.run(
+    "Tabletop Game",
+    orc,
+    human,
+    "W",
+    2,
+    0,
+    "2024-01-08",
+    tabletop,
+    fmt("tournament", tabletop),
+  );
   // Extra BB3 games: brings total to 13 (>10 for pagination) and BB3 to 11 (>10 when platform-filtered)
-  ins.run('BB3 Extra 1',    orc,   human,  'W', 2, 1, '2024-01-09', bb3,      fmt('league',     bb3));
-  ins.run('BB3 Extra 2',    orc,   human,  'W', 2, 1, '2024-01-10', bb3,      fmt('league',     bb3));
-  ins.run('BB3 Extra 3',    orc,   human,  'W', 2, 1, '2024-01-11', bb3,      fmt('league',     bb3));
-  ins.run('BB3 Extra 4',    orc,   human,  'W', 2, 1, '2024-01-12', bb3,      fmt('league',     bb3));
-  ins.run('BB3 Extra 5',    orc,   human,  'W', 2, 1, '2024-01-13', bb3,      fmt('league',     bb3));
+  ins.run("BB3 Extra 1", orc, human, "W", 2, 1, "2024-01-09", bb3, fmt("league", bb3));
+  ins.run("BB3 Extra 2", orc, human, "W", 2, 1, "2024-01-10", bb3, fmt("league", bb3));
+  ins.run("BB3 Extra 3", orc, human, "W", 2, 1, "2024-01-11", bb3, fmt("league", bb3));
+  ins.run("BB3 Extra 4", orc, human, "W", 2, 1, "2024-01-12", bb3, fmt("league", bb3));
+  ins.run("BB3 Extra 5", orc, human, "W", 2, 1, "2024-01-13", bb3, fmt("league", bb3));
 })();
 
 db.close();
-console.log('Seeded 13 test games into', DB_PATH);
+console.log("Seeded 13 test games into", DB_PATH);

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,8 +1,12 @@
-import { defineCollection, z } from 'astro:content';
-import { glob } from 'astro/loaders';
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
 
 const postsCollection = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: './src/content/posts', generateId: ({ entry }) => entry.replace(/\.md$/, '') }),
+  loader: glob({
+    pattern: "**/*.md",
+    base: "./src/content/posts",
+    generateId: ({ entry }) => entry.replace(/\.md$/, ""),
+  }),
   schema: z.object({
     title: z.string(),
     description: z.string().optional(),
@@ -14,5 +18,5 @@ const postsCollection = defineCollection({
 });
 
 export const collections = {
-  'posts': postsCollection,
+  posts: postsCollection,
 };

--- a/src/content/posts/git-alias.md
+++ b/src/content/posts/git-alias.md
@@ -1,29 +1,30 @@
 ---
-title: Creating a git alias to trigger a rebuild 
-description: See how to create git aliases can improve your productivity.  
+title: Creating a git alias to trigger a rebuild
+description: See how to create git aliases can improve your productivity.
 date: 2022-02-15
 tags:
- - programming
+  - programming
 # layout: ../../layouts/BaseLayout.astro
 ---
 
-Confession time.  For quite a while I've been making meaningless manual changes in my PR's during when CI processes fail due to test flake.  Recently, however, a new member of the team enlightened me.  You can create empty commits in git by adding the `--allow-empty` flag to commit.  This is certainly a huge productivity benefit.  This week the test flake has gotten real, but I don't have time to deal with that.  Manually typing out a commit and push is feeling like such a burden.
+Confession time. For quite a while I've been making meaningless manual changes in my PR's during when CI processes fail due to test flake. Recently, however, a new member of the team enlightened me. You can create empty commits in git by adding the `--allow-empty` flag to commit. This is certainly a huge productivity benefit. This week the test flake has gotten real, but I don't have time to deal with that. Manually typing out a commit and push is feeling like such a burden.
 
 ```sh
 > git commit --allow-empty -m "trigger rebuild"
 > git push
 ```
-So much work!  Thankfully, today I learned about git aliases and now I can simply run `git rebuild`.  Much better!  Here's how to do it.
 
-First, open the `.gitconfig` file with your favorite text editor.  Most likely this is in your home directory.  If you're using macOS, open Finder and navigate to the `Users/[yourUserName]` directory.  The file may be hidden.  If you don't see it then press `shift + cmd + .`.  
+So much work! Thankfully, today I learned about git aliases and now I can simply run `git rebuild`. Much better! Here's how to do it.
 
-After the file is open in your text editor add an alias section and your command and save the file.  The result should look like this:
+First, open the `.gitconfig` file with your favorite text editor. Most likely this is in your home directory. If you're using macOS, open Finder and navigate to the `Users/[yourUserName]` directory. The file may be hidden. If you don't see it then press `shift + cmd + .`.
+
+After the file is open in your text editor add an alias section and your command and save the file. The result should look like this:
 
 ```
 [alias]
   rebuild = !git commit --allow-empty -m 'trigger rebuild' && git push
 ```
 
-Try it out!  You can open your terminal, and run a simple `git rebuild` command to create and push your empty commit.
+Try it out! You can open your terminal, and run a simple `git rebuild` command to create and push your empty commit.
 
-This opens up a whole world of new possibilities to explore! It's easy to envision many ways to create new simple shortcuts.  Even small thing small like creating a shortcut checkout a branch with a `git co` command instead of `git checkout` offers some nice developer experience improvements.  
+This opens up a whole world of new possibilities to explore! It's easy to envision many ways to create new simple shortcuts. Even small thing small like creating a shortcut checkout a branch with a `git co` command instead of `git checkout` offers some nice developer experience improvements.

--- a/src/content/posts/jest-naming-conventions.md
+++ b/src/content/posts/jest-naming-conventions.md
@@ -3,11 +3,10 @@ title: Jest Testing Conventions
 description: My opinions of conventions teams should adopt when using Jest.
 date: 2020-03-26
 tags:
- - programming
+  - programming
 # layout: ../../layouts/BaseLayout.astro
 ---
 
-Over the last several months our frontend development team has grown. As a result, I am spending more time on code reviews. I found I was providing similar feedback about unit tests to different members of the team. On multiple occasions, I have said, "You know I should probably write this stuff down. Then we can link to it future reviews. It will save me some keystrokes and conversations." After dragging my feet for a few days, I finally posted some of my expectations on GitHub. You can see them here: [Jest Testing Conventions](https://github.com/sleslein/vscode/blob/master/jest-testing-conventions.md) 
+Over the last several months our frontend development team has grown. As a result, I am spending more time on code reviews. I found I was providing similar feedback about unit tests to different members of the team. On multiple occasions, I have said, "You know I should probably write this stuff down. Then we can link to it future reviews. It will save me some keystrokes and conversations." After dragging my feet for a few days, I finally posted some of my expectations on GitHub. You can see them here: [Jest Testing Conventions](https://github.com/sleslein/vscode/blob/master/jest-testing-conventions.md)
 
 The goal of these is not to dictate every jot and tittle, but rather provide loose guidelines that will provide a consistent look and feel to the test code. Experience has taught me the consistency conventions offer can be a [force multipliers](https://ardalis.com/becoming-a-developer-team-force-multiplier/) on development teams.
-

--- a/src/content/posts/to-kill-a-process.md
+++ b/src/content/posts/to-kill-a-process.md
@@ -3,19 +3,19 @@ title: How to Kill a Process Listening on a Port
 description: A simple function for killing processes listening to a specific port.
 date: 2020-04-22
 tags:
- - programming
+  - programming
 # layout: ../../layouts/BaseLayout.astro
 ---
 
-As a front-end web developer I'm constantly starting and stopping my local webpack dev server. Starting the server is as easy as `yarn start`. Node starts up, and I'm off to the races. Stopping is easy too, `ctrl + c`. Well, stopping is easy so long as I have the terminal I started the process available. When I don't, I need to find the process that is listening to the port and close it.  
+As a front-end web developer I'm constantly starting and stopping my local webpack dev server. Starting the server is as easy as `yarn start`. Node starts up, and I'm off to the races. Stopping is easy too, `ctrl + c`. Well, stopping is easy so long as I have the terminal I started the process available. When I don't, I need to find the process that is listening to the port and close it.
 
-What's a developer to do? Head to [Duck Duck Go](https://duckduckgo.com/) and search for "find a process listening to port on mac". Well, this has happened several times over the last couple of weeks. Each time I went to [the same article](https://tips.tutorialhorizon.com/2017/08/30/find-the-process-running-on-a-port-on-your-mac/) which gave me the following command: 
+What's a developer to do? Head to [Duck Duck Go](https://duckduckgo.com/) and search for "find a process listening to port on mac". Well, this has happened several times over the last couple of weeks. Each time I went to [the same article](https://tips.tutorialhorizon.com/2017/08/30/find-the-process-running-on-a-port-on-your-mac/) which gave me the following command:
 
 `lsof -n -i4TCP:8080 | grep LISTEN | awk '{print $2}' | xargs kill -9`
 
-Easy peasy! Update my port number.  Press enter.  The process is terminated and I'm back in business.
+Easy peasy! Update my port number. Press enter. The process is terminated and I'm back in business.
 
-This works great! However, I have some problems with this. I'm lazy. I cannot remember this whole command. Honestly, I don't want to either. So, I added the following function to my `.zshrc` file.  
+This works great! However, I have some problems with this. I'm lazy. I cannot remember this whole command. Honestly, I don't want to either. So, I added the following function to my `.zshrc` file.
 
 ```
 # kill_port_proc <port>
@@ -35,4 +35,4 @@ function kill_port_proc {
 }
 ```
 
-This function performs the same commands recommend in the article.  It even tells me if no process exists. Now the next time I see the dreaded `Error: listen EADDRINUSE: address already in use 0.0.0.0:5555` message in my terminal because an old node process is already running, I don't need to search the web.  I can simply run this command, `kill_port_proc 5555`
+This function performs the same commands recommend in the article. It even tells me if no process exists. Now the next time I see the dreaded `Error: listen EADDRINUSE: address already in use 0.0.0.0:5555` message in my terminal because an old node process is already running, I don't need to search the web. I can simply run this command, `kill_port_proc 5555`

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,12 +1,12 @@
-import Database from 'better-sqlite3';
-import fs from 'fs';
-import path from 'path';
+import Database from "better-sqlite3";
+import fs from "fs";
+import path from "path";
 
-const DB_PATH = process.env.DB_PATH || (
-  process.env.NODE_ENV === 'production'
-    ? path.join('/data', 'bloodbowl.db')
-    : path.join(process.cwd(), 'data', 'bloodbowl.db')
-);
+const DB_PATH =
+  process.env.DB_PATH ||
+  (process.env.NODE_ENV === "production"
+    ? path.join("/data", "bloodbowl.db")
+    : path.join(process.cwd(), "data", "bloodbowl.db"));
 
 let db: Database.Database | null = null;
 
@@ -15,7 +15,7 @@ export function getDb(): Database.Database {
 
   fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
   db = new Database(DB_PATH);
-  db.pragma('journal_mode = WAL');
+  db.pragma("journal_mode = WAL");
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS teams (
@@ -53,41 +53,69 @@ export function getDb(): Database.Database {
 
   const insertTeam = db.prepare(`INSERT OR IGNORE INTO teams (name) VALUES (?)`);
   for (const name of [
-    'Amazon', 'Black Orc', 'Bretonnian', 'Chaos Chosen', 'Chaos Dwarf',
-    'Chaos Renegade', 'Dark Elf', 'Dwarf', 'Elven Union', 'Gnome', 'Goblin',
-    'Halfling', 'High Elf', 'Human', 'Imperial Nobility', 'Khorne',
-    'Lizardmen', 'Necromantic Horror', 'Norse', 'Nurgle', 'Ogre',
-    'Old World Alliance', 'Orc', 'Shambling Undead', 'Skaven', 'Snotling',
-    'Tomb Kings', 'Underworld Denizens', 'Vampire', 'Wood Elf',
+    "Amazon",
+    "Black Orc",
+    "Bretonnian",
+    "Chaos Chosen",
+    "Chaos Dwarf",
+    "Chaos Renegade",
+    "Dark Elf",
+    "Dwarf",
+    "Elven Union",
+    "Gnome",
+    "Goblin",
+    "Halfling",
+    "High Elf",
+    "Human",
+    "Imperial Nobility",
+    "Khorne",
+    "Lizardmen",
+    "Necromantic Horror",
+    "Norse",
+    "Nurgle",
+    "Ogre",
+    "Old World Alliance",
+    "Orc",
+    "Shambling Undead",
+    "Skaven",
+    "Snotling",
+    "Tomb Kings",
+    "Underworld Denizens",
+    "Vampire",
+    "Wood Elf",
   ]) {
     insertTeam.run(name);
   }
 
   const insertPlatform = db.prepare(`INSERT OR IGNORE INTO platforms (name) VALUES (?)`);
-  for (const name of ['Blood Bowl 3', 'Fumbbl', 'tabletop']) {
+  for (const name of ["Blood Bowl 3", "Fumbbl", "tabletop"]) {
     insertPlatform.run(name);
   }
 
-  const getPlatformId = db.prepare<[string], { id: number }>(`SELECT id FROM platforms WHERE name = ?`);
-  const bb3Id      = getPlatformId.get('Blood Bowl 3')!.id;
-  const fumbbId    = getPlatformId.get('Fumbbl')!.id;
-  const tabletopId = getPlatformId.get('tabletop')!.id;
+  const getPlatformId = db.prepare<[string], { id: number }>(
+    `SELECT id FROM platforms WHERE name = ?`,
+  );
+  const bb3Id = getPlatformId.get("Blood Bowl 3")!.id;
+  const fumbbId = getPlatformId.get("Fumbbl")!.id;
+  const tabletopId = getPlatformId.get("tabletop")!.id;
 
-  const insertFormat = db.prepare(`INSERT OR IGNORE INTO formats (name, platform_id) VALUES (?, ?)`);
+  const insertFormat = db.prepare(
+    `INSERT OR IGNORE INTO formats (name, platform_id) VALUES (?, ?)`,
+  );
   for (const [name, platform_id] of [
-    ['league',          bb3Id],
-    ['ladder',          bb3Id],
-    ['resurrection',    bb3Id],
-    ['community event', bb3Id],
-    ['friendly',        bb3Id],
-    ['league',          fumbbId],
-    ['ladder',          fumbbId],
-    ['resurrection',    fumbbId],
-    ['community event', fumbbId],
-    ['friendly',        fumbbId],
-    ['league',          tabletopId],
-    ['tournament',      tabletopId],
-    ['friendly',        tabletopId],
+    ["league", bb3Id],
+    ["ladder", bb3Id],
+    ["resurrection", bb3Id],
+    ["community event", bb3Id],
+    ["friendly", bb3Id],
+    ["league", fumbbId],
+    ["ladder", fumbbId],
+    ["resurrection", fumbbId],
+    ["community event", fumbbId],
+    ["friendly", fumbbId],
+    ["league", tabletopId],
+    ["tournament", tabletopId],
+    ["friendly", tabletopId],
   ] as [string, number][]) {
     insertFormat.run(name, platform_id);
   }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,4 +1,4 @@
-import { getDb } from './db';
+import { getDb } from "./db";
 
 export interface Game {
   id: number;
@@ -6,7 +6,7 @@ export interface Game {
   opponent_name: string;
   my_race: string;
   opponent_race: string;
-  result: 'W' | 'L' | 'D';
+  result: "W" | "L" | "D";
   score_for: number;
   score_against: number;
   platform: string;
@@ -36,7 +36,7 @@ export interface RawGame {
   opponent_name: string;
   my_race_id: number;
   opponent_race_id: number;
-  result: 'W' | 'L' | 'D';
+  result: "W" | "L" | "D";
   score_for: number;
   score_against: number;
   platform_id: number;
@@ -48,7 +48,7 @@ export interface InsertGameData {
   opponent_name: string;
   my_race_id: number;
   opponent_race_id: number;
-  result: 'W' | 'L' | 'D';
+  result: "W" | "L" | "D";
   score_for: number;
   score_against: number;
   date: string;
@@ -58,7 +58,8 @@ export interface InsertGameData {
 }
 
 export function getGames(): Game[] {
-  return getDb().prepare(`
+  return getDb()
+    .prepare(`
     SELECT
       g.id,
       g.date,
@@ -77,7 +78,8 @@ export function getGames(): Game[] {
     JOIN platforms p  ON p.id  = g.platform_id
     JOIN formats   f  ON f.id  = g.format_id
     ORDER BY g.date DESC
-  `).all() as Game[];
+  `)
+    .all() as Game[];
 }
 
 export function getTeams(): Team[] {
@@ -89,11 +91,14 @@ export function getPlatforms(): Platform[] {
 }
 
 export function getFormats(): Format[] {
-  return getDb().prepare(`SELECT id, name, platform_id FROM formats ORDER BY name`).all() as Format[];
+  return getDb()
+    .prepare(`SELECT id, name, platform_id FROM formats ORDER BY name`)
+    .all() as Format[];
 }
 
 export function getGame(id: number): Game | undefined {
-  return getDb().prepare(`
+  return getDb()
+    .prepare(`
     SELECT
       g.id,
       g.date,
@@ -112,15 +117,18 @@ export function getGame(id: number): Game | undefined {
     JOIN platforms p  ON p.id  = g.platform_id
     JOIN formats   f  ON f.id  = g.format_id
     WHERE g.id = ?
-  `).get(id) as Game | undefined;
+  `)
+    .get(id) as Game | undefined;
 }
 
 export function getRawGame(id: number): RawGame | undefined {
-  return getDb().prepare(`
+  return getDb()
+    .prepare(`
     SELECT id, date, opponent_name, my_race_id, opponent_race_id, result,
            score_for, score_against, platform_id, format_id, notes
     FROM games WHERE id = ?
-  `).get(id) as RawGame | undefined;
+  `)
+    .get(id) as RawGame | undefined;
 }
 
 export function deleteGame(id: number): void {
@@ -128,7 +136,8 @@ export function deleteGame(id: number): void {
 }
 
 export function updateGame(id: number, data: InsertGameData): void {
-  getDb().prepare(`
+  getDb()
+    .prepare(`
     UPDATE games
     SET opponent_name    = ?,
         my_race_id       = ?,
@@ -141,35 +150,38 @@ export function updateGame(id: number, data: InsertGameData): void {
         format_id        = ?,
         notes            = ?
     WHERE id = ?
-  `).run(
-    data.opponent_name,
-    data.my_race_id,
-    data.opponent_race_id,
-    data.result,
-    data.score_for,
-    data.score_against,
-    data.date,
-    data.platform_id,
-    data.format_id,
-    data.notes,
-    id,
-  );
+  `)
+    .run(
+      data.opponent_name,
+      data.my_race_id,
+      data.opponent_race_id,
+      data.result,
+      data.score_for,
+      data.score_against,
+      data.date,
+      data.platform_id,
+      data.format_id,
+      data.notes,
+      id,
+    );
 }
 
 export function insertGame(data: InsertGameData): void {
-  getDb().prepare(`
+  getDb()
+    .prepare(`
     INSERT INTO games (opponent_name, my_race_id, opponent_race_id, result, score_for, score_against, date, platform_id, format_id, notes)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(
-    data.opponent_name,
-    data.my_race_id,
-    data.opponent_race_id,
-    data.result,
-    data.score_for,
-    data.score_against,
-    data.date,
-    data.platform_id,
-    data.format_id,
-    data.notes,
-  );
+  `)
+    .run(
+      data.opponent_name,
+      data.my_race_id,
+      data.opponent_race_id,
+      data.result,
+      data.score_for,
+      data.score_against,
+      data.date,
+      data.platform_id,
+      data.format_id,
+      data.notes,
+    );
 }

--- a/src/lib/seed.ts
+++ b/src/lib/seed.ts
@@ -1,39 +1,39 @@
-import { getDb } from './db';
+import { getDb } from "./db";
 
 const db = getDb();
 
 // Teams
 const teams = [
-  'Amazon',
-  'Black Orc',
-  'Bretonnian',
-  'Chaos Chosen',
-  'Chaos Dwarf',
-  'Chaos Renegade',
-  'Dark Elf',
-  'Dwarf',
-  'Elven Union',
-  'Gnome',
-  'Goblin',
-  'Halfling',
-  'High Elf',
-  'Human',
-  'Imperial Nobility',
-  'Khorne',
-  'Lizardmen',
-  'Necromantic Horror',
-  'Norse',
-  'Nurgle',
-  'Ogre',
-  'Old World Alliance',
-  'Orc',
-  'Shambling Undead',
-  'Skaven',
-  'Snotling',
-  'Tomb Kings',
-  'Underworld Denizens',
-  'Vampire',
-  'Wood Elf',
+  "Amazon",
+  "Black Orc",
+  "Bretonnian",
+  "Chaos Chosen",
+  "Chaos Dwarf",
+  "Chaos Renegade",
+  "Dark Elf",
+  "Dwarf",
+  "Elven Union",
+  "Gnome",
+  "Goblin",
+  "Halfling",
+  "High Elf",
+  "Human",
+  "Imperial Nobility",
+  "Khorne",
+  "Lizardmen",
+  "Necromantic Horror",
+  "Norse",
+  "Nurgle",
+  "Ogre",
+  "Old World Alliance",
+  "Orc",
+  "Shambling Undead",
+  "Skaven",
+  "Snotling",
+  "Tomb Kings",
+  "Underworld Denizens",
+  "Vampire",
+  "Wood Elf",
 ];
 
 const insertTeam = db.prepare(`INSERT OR IGNORE INTO teams (name) VALUES (?)`);
@@ -43,7 +43,7 @@ for (const name of teams) {
 console.log(`Seeded ${teams.length} teams`);
 
 // Platforms
-const platforms = ['Blood Bowl 3', 'Fumbbl', 'tabletop'];
+const platforms = ["Blood Bowl 3", "Fumbbl", "tabletop"];
 const insertPlatform = db.prepare(`INSERT OR IGNORE INTO platforms (name) VALUES (?)`);
 for (const name of platforms) {
   insertPlatform.run(name);
@@ -51,24 +51,30 @@ for (const name of platforms) {
 console.log(`Seeded ${platforms.length} platforms`);
 
 // Formats
-const bb3Id      = (db.prepare(`SELECT id FROM platforms WHERE name = 'Blood Bowl 3'`).get() as { id: number }).id;
-const fumbbId    = (db.prepare(`SELECT id FROM platforms WHERE name = 'Fumbbl'`).get() as { id: number }).id;
-const tabletopId = (db.prepare(`SELECT id FROM platforms WHERE name = 'tabletop'`).get() as { id: number }).id;
+const bb3Id = (
+  db.prepare(`SELECT id FROM platforms WHERE name = 'Blood Bowl 3'`).get() as { id: number }
+).id;
+const fumbbId = (
+  db.prepare(`SELECT id FROM platforms WHERE name = 'Fumbbl'`).get() as { id: number }
+).id;
+const tabletopId = (
+  db.prepare(`SELECT id FROM platforms WHERE name = 'tabletop'`).get() as { id: number }
+).id;
 
 const formats: { name: string; platform_id: number }[] = [
-  { name: 'league',          platform_id: bb3Id },
-  { name: 'ladder',          platform_id: bb3Id },
-  { name: 'resurrection',    platform_id: bb3Id },
-  { name: 'community event', platform_id: bb3Id },
-  { name: 'friendly',        platform_id: bb3Id },
-  { name: 'league',          platform_id: fumbbId },
-  { name: 'ladder',          platform_id: fumbbId },
-  { name: 'resurrection',    platform_id: fumbbId },
-  { name: 'community event', platform_id: fumbbId },
-  { name: 'friendly',        platform_id: fumbbId },
-  { name: 'league',          platform_id: tabletopId },
-  { name: 'tournament',      platform_id: tabletopId },
-  { name: 'friendly',        platform_id: tabletopId },
+  { name: "league", platform_id: bb3Id },
+  { name: "ladder", platform_id: bb3Id },
+  { name: "resurrection", platform_id: bb3Id },
+  { name: "community event", platform_id: bb3Id },
+  { name: "friendly", platform_id: bb3Id },
+  { name: "league", platform_id: fumbbId },
+  { name: "ladder", platform_id: fumbbId },
+  { name: "resurrection", platform_id: fumbbId },
+  { name: "community event", platform_id: fumbbId },
+  { name: "friendly", platform_id: fumbbId },
+  { name: "league", platform_id: tabletopId },
+  { name: "tournament", platform_id: tabletopId },
+  { name: "friendly", platform_id: tabletopId },
 ];
 
 const insertFormat = db.prepare(`INSERT OR IGNORE INTO formats (name, platform_id) VALUES (?, ?)`);

--- a/src/pages/about/index.md
+++ b/src/pages/about/index.md
@@ -1,8 +1,8 @@
 ---
-layout: '../../layouts/BaseLayout.astro'
+layout: "../../layouts/BaseLayout.astro"
 title: About Me
 ---
 
 Hi! I'm Shea. I'm a born and raised Iowan living in foreign lands, aka, Chicagoland. Since graduating from Iowa State Univerity, I've devoted myself to a life as a software engineer, father, husband, and follower of Jesus. It's all busy, but I wouldn't change it for the world!
 
-I created this blog to share about all of the things I'm devoted to. Maybe we have something in common and my experiences and perspectives will help you out someday! The next best thing would be if I can Google myself for an answer I have forgotten! 
+I created this blog to share about all of the things I'm devoted to. Maybe we have something in common and my experiences and perspectives will help you out someday! The next best thing would be if I can Google myself for an answer I have forgotten!

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,85 +1,85 @@
 :root {
-    --white: #fff;
-    --primary: #189ab4;
-    --black: #010;
+  --white: #fff;
+  --primary: #189ab4;
+  --black: #010;
 }
 
 html,
 body {
-    padding: 0;
-    margin: 0;
-    font-family: system-ui, sans-serif;
+  padding: 0;
+  margin: 0;
+  font-family: system-ui, sans-serif;
 }
 a {
-    color:  var(--black);
+  color: var(--black);
 }
 
 a:hover {
-    color: var(--primary);
+  color: var(--primary);
 }
 
 /* Header */
 header {
-    border-top: 10px solid var(--primary);
-    padding: 0 1rem;
-    display: flex;
-    align-items: center;
+  border-top: 10px solid var(--primary);
+  padding: 0 1rem;
+  display: flex;
+  align-items: center;
 }
 
 header img {
-    border-radius: 50%;
-    height: 4.5em;
-    width: 4.5em;
+  border-radius: 50%;
+  height: 4.5em;
+  width: 4.5em;
 }
 
 header h1 {
-    padding-bottom: .75rem;
-    margin: 0; 
-    font-size: 2em; 
+  padding-bottom: 0.75rem;
+  margin: 0;
+  font-size: 2em;
 }
-  
+
 header h1 a,
 header h1 a:hover {
-    text-decoration: none;
-    color:black;
+  text-decoration: none;
+  color: black;
 }
 
 /* Nav */
 .nav {
-    padding: 0;
-    list-style: none;
-    margin-left: 1em;
+  padding: 0;
+  list-style: none;
+  margin-left: 1em;
 }
 .nav-item {
-    display: inline-block;
-    margin-right: 1em;
-    font-size: 1.25em;
-    border-bottom: solid 2px transparent;
+  display: inline-block;
+  margin-right: 1em;
+  font-size: 1.25em;
+  border-bottom: solid 2px transparent;
 }
 
 .nav-item:hover {
-    border-bottom: solid 2px #75e6da;
+  border-bottom: solid 2px #75e6da;
 }
 
 .nav-item a {
-    text-decoration: none;
-    color:black;
+  text-decoration: none;
+  color: black;
 }
 
 main {
-    max-width: 64rem;
-    margin: 0 auto;
-    padding: 0 3rem;
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 0 3rem;
 }
 
 code {
-    display: inline-block;
-    background-color: #eaeff5;
-    padding: 0 .25rem;
+  display: inline-block;
+  background-color: #eaeff5;
+  padding: 0 0.25rem;
 }
 
 pre code {
-    display: block;
-    padding: .5rem;
-    margin: .5rem 0;
+  display: block;
+  padding: 0.5rem;
+  margin: 0.5rem 0;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 export function formatDate(date: Date): string {
-  const options = { year: "numeric", month: 'short', day: "numeric" } as const;
-  const formatter = new Intl.DateTimeFormat('en-US', options);
+  const options = { year: "numeric", month: "short", day: "numeric" } as const;
+  const formatter = new Intl.DateTimeFormat("en-US", options);
   return formatter.format(date);
 }
 

--- a/tests/blood-bowl.spec.ts
+++ b/tests/blood-bowl.spec.ts
@@ -1,200 +1,200 @@
-import { test, expect, type Page } from '@playwright/test';
-import Database from 'better-sqlite3';
-import { execSync } from 'child_process';
-import path from 'path';
+import { test, expect, type Page } from "@playwright/test";
+import Database from "better-sqlite3";
+import { execSync } from "child_process";
+import path from "path";
 
-const PASSWORD = process.env.BLOOD_BOWL_KEY ?? '';
-const TEST_DB  = path.join(process.cwd(), 'data', 'test.db');
+const PASSWORD = process.env.BLOOD_BOWL_KEY ?? "";
+const TEST_DB = path.join(process.cwd(), "data", "test.db");
 
 test.beforeEach(() => {
   const db = new Database(TEST_DB);
-  db.prepare('DELETE FROM games').run();
+  db.prepare("DELETE FROM games").run();
   db.close();
-  execSync('node scripts/seed-test.js', { env: { ...process.env, DB_PATH: TEST_DB } });
+  execSync("node scripts/seed-test.js", { env: { ...process.env, DB_PATH: TEST_DB } });
 });
 
 // --- UI helper ---
 
 async function addGame(page: Page, opponentName: string) {
-  await page.goto('/blood-bowl/add');
-  await page.getByLabel('Date').fill('2026-03-21');
-  await page.getByLabel('Opponent name').fill(opponentName);
-  await page.getByLabel('My race').selectOption({ label: 'Orc' });
-  await page.getByLabel('Opponent race').selectOption({ label: 'Human' });
-  await page.getByLabel('Result').selectOption('W');
-  await page.getByLabel('Score for').fill('2');
-  await page.getByLabel('Score against').fill('1');
-  await page.getByLabel('Platform').selectOption({ label: 'Blood Bowl 3' });
-  await page.getByLabel('Format').selectOption({ label: 'league' });
-  await page.getByLabel('Password').fill(PASSWORD);
-  await page.getByRole('button', { name: 'Add game' }).click();
-  await expect(page).toHaveURL('/blood-bowl/');
+  await page.goto("/blood-bowl/add");
+  await page.getByLabel("Date").fill("2026-03-21");
+  await page.getByLabel("Opponent name").fill(opponentName);
+  await page.getByLabel("My race").selectOption({ label: "Orc" });
+  await page.getByLabel("Opponent race").selectOption({ label: "Human" });
+  await page.getByLabel("Result").selectOption("W");
+  await page.getByLabel("Score for").fill("2");
+  await page.getByLabel("Score against").fill("1");
+  await page.getByLabel("Platform").selectOption({ label: "Blood Bowl 3" });
+  await page.getByLabel("Format").selectOption({ label: "league" });
+  await page.getByLabel("Password").fill(PASSWORD);
+  await page.getByRole("button", { name: "Add game" }).click();
+  await expect(page).toHaveURL("/blood-bowl/");
 }
 
 // --- CRUD ---
 
-test('add a game', async ({ page }) => {
+test("add a game", async ({ page }) => {
   const name = `Add-Test-${Date.now()}`;
   await addGame(page, name);
-  await expect(page.getByRole('table', { name: 'Games' })).toContainText(name);
+  await expect(page.getByRole("table", { name: "Games" })).toContainText(name);
 });
 
-test('edit a game', async ({ page }) => {
-  const name       = `Edit-Test-${Date.now()}`;
+test("edit a game", async ({ page }) => {
+  const name = `Edit-Test-${Date.now()}`;
   const editedName = `Edited-${Date.now()}`;
   await addGame(page, name);
 
-  const row = page.getByRole('table', { name: 'Games' }).getByRole('row').filter({ hasText: name });
-  await row.getByRole('link', { name: 'Edit' }).click();
+  const row = page.getByRole("table", { name: "Games" }).getByRole("row").filter({ hasText: name });
+  await row.getByRole("link", { name: "Edit" }).click();
   await expect(page).toHaveURL(/\/blood-bowl\/edit/);
 
-  await page.getByLabel('Opponent name').fill(editedName);
-  await page.getByLabel('Password').fill(PASSWORD);
-  await page.getByRole('button', { name: 'Save changes' }).click();
+  await page.getByLabel("Opponent name").fill(editedName);
+  await page.getByLabel("Password").fill(PASSWORD);
+  await page.getByRole("button", { name: "Save changes" }).click();
 
-  await expect(page).toHaveURL('/blood-bowl/');
-  await expect(page.getByRole('table', { name: 'Games' })).toContainText(editedName);
-  await expect(page.getByRole('table', { name: 'Games' })).not.toContainText(name);
+  await expect(page).toHaveURL("/blood-bowl/");
+  await expect(page.getByRole("table", { name: "Games" })).toContainText(editedName);
+  await expect(page.getByRole("table", { name: "Games" })).not.toContainText(name);
 });
 
-test('delete a game', async ({ page }) => {
+test("delete a game", async ({ page }) => {
   const name = `Delete-Test-${Date.now()}`;
   await addGame(page, name);
 
-  const row = page.getByRole('table', { name: 'Games' }).getByRole('row').filter({ hasText: name });
-  await row.getByRole('link', { name: 'Delete' }).click();
+  const row = page.getByRole("table", { name: "Games" }).getByRole("row").filter({ hasText: name });
+  await row.getByRole("link", { name: "Delete" }).click();
   await expect(page).toHaveURL(/\/blood-bowl\/delete/);
 
-  await page.getByLabel('Password').fill(PASSWORD);
-  await page.getByRole('button', { name: 'Delete' }).click();
+  await page.getByLabel("Password").fill(PASSWORD);
+  await page.getByRole("button", { name: "Delete" }).click();
 
-  await expect(page).toHaveURL('/blood-bowl/');
-  await expect(page.getByRole('main')).not.toContainText(name);
+  await expect(page).toHaveURL("/blood-bowl/");
+  await expect(page.getByRole("main")).not.toContainText(name);
 });
 
 // --- W/D/L ordering ---
 
-test('stats card shows results in W/D/L order', async ({ page }) => {
+test("stats card shows results in W/D/L order", async ({ page }) => {
   // Seed contains Seed W Game, Seed D Game, Seed L Game
-  await page.goto('/blood-bowl');
-  const text = await page.locator('.overall').textContent() ?? '';
-  expect(text.indexOf('W')).toBeLessThan(text.indexOf('D'));
-  expect(text.indexOf('D')).toBeLessThan(text.indexOf('L'));
+  await page.goto("/blood-bowl");
+  const text = (await page.locator(".overall").textContent()) ?? "";
+  expect(text.indexOf("W")).toBeLessThan(text.indexOf("D"));
+  expect(text.indexOf("D")).toBeLessThan(text.indexOf("L"));
 });
 
 // --- Add game link position ---
 
-test('add game link appears above the game table', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  const linkY  = (await page.getByRole('link', { name: '+ Add game' }).boundingBox())!.y;
-  const tableY = (await page.getByRole('table', { name: 'Games' }).boundingBox())!.y;
+test("add game link appears above the game table", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  const linkY = (await page.getByRole("link", { name: "+ Add game" }).boundingBox())!.y;
+  const tableY = (await page.getByRole("table", { name: "Games" }).boundingBox())!.y;
   expect(linkY).toBeLessThan(tableY);
 });
 
 // --- Pagination (13 seeded games: 10 on page 1, 3 on page 2) ---
 
-test('shows 10 games per page', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
+test("shows 10 games per page", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  const rows = page.getByRole("table", { name: "Games" }).getByRole("row");
   await expect(rows).toHaveCount(11); // 1 header + 10 data rows
 });
 
-test('next link navigates to page 2', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  await page.getByRole('link', { name: /Next/ }).click();
+test("next link navigates to page 2", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  await page.getByRole("link", { name: /Next/ }).click();
   await expect(page).toHaveURL(/page=2/);
-  const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
+  const rows = page.getByRole("table", { name: "Games" }).getByRole("row");
   await expect(rows).toHaveCount(4); // 1 header + 3 games
 });
 
-test('prev link navigates back to page 1', async ({ page }) => {
-  await page.goto('/blood-bowl?page=2');
-  await page.getByRole('link', { name: /Prev/ }).click();
+test("prev link navigates back to page 1", async ({ page }) => {
+  await page.goto("/blood-bowl?page=2");
+  await page.getByRole("link", { name: /Prev/ }).click();
   await expect(page).toHaveURL(/page=1/);
-  const rows = page.getByRole('table', { name: 'Games' }).getByRole('row');
+  const rows = page.getByRole("table", { name: "Games" }).getByRole("row");
   await expect(rows).toHaveCount(11); // 1 header + 10 data rows
 });
 
-test('prev is disabled on page 1', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  await expect(page.getByRole('link', { name: /Prev/ })).not.toBeVisible();
-  await expect(page.locator('.disabled', { hasText: 'Prev' })).toBeVisible();
+test("prev is disabled on page 1", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  await expect(page.getByRole("link", { name: /Prev/ })).not.toBeVisible();
+  await expect(page.locator(".disabled", { hasText: "Prev" })).toBeVisible();
 });
 
-test('next is disabled on the last page', async ({ page }) => {
-  await page.goto('/blood-bowl?page=2');
-  await expect(page.getByRole('link', { name: /Next/ })).not.toBeVisible();
-  await expect(page.locator('.disabled', { hasText: 'Next' })).toBeVisible();
+test("next is disabled on the last page", async ({ page }) => {
+  await page.goto("/blood-bowl?page=2");
+  await expect(page.getByRole("link", { name: /Next/ })).not.toBeVisible();
+  await expect(page.locator(".disabled", { hasText: "Next" })).toBeVisible();
 });
 
 // --- Filters (use seed data directly) ---
 
-test('platform filter narrows results', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  await page.getByLabel('Platform').selectOption('Blood Bowl 3');
-  await page.getByRole('button', { name: 'Filter' }).click();
-  const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('BB3 Extra 5');
-  await expect(table).not.toContainText('Fumbbl Game');
+test("platform filter narrows results", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  await page.getByLabel("Platform").selectOption("Blood Bowl 3");
+  await page.getByRole("button", { name: "Filter" }).click();
+  const table = page.getByRole("table", { name: "Games" });
+  await expect(table).toContainText("BB3 Extra 5");
+  await expect(table).not.toContainText("Fumbbl Game");
 });
 
-test('format filter narrows results', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  await page.getByLabel('Format').selectOption('league');
-  await page.getByRole('button', { name: 'Filter' }).click();
-  const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('BB3 Extra 5');
-  await expect(table).not.toContainText('Ladder Game');
+test("format filter narrows results", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  await page.getByLabel("Format").selectOption("league");
+  await page.getByRole("button", { name: "Filter" }).click();
+  const table = page.getByRole("table", { name: "Games" });
+  await expect(table).toContainText("BB3 Extra 5");
+  await expect(table).not.toContainText("Ladder Game");
 });
 
-test('my race filter narrows results', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  await page.getByLabel('My Race').selectOption('Orc');
-  await page.getByRole('button', { name: 'Filter' }).click();
-  const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('BB3 Extra 5');
-  await expect(table).not.toContainText('Dwarf Game');
+test("my race filter narrows results", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  await page.getByLabel("My Race").selectOption("Orc");
+  await page.getByRole("button", { name: "Filter" }).click();
+  const table = page.getByRole("table", { name: "Games" });
+  await expect(table).toContainText("BB3 Extra 5");
+  await expect(table).not.toContainText("Dwarf Game");
 });
 
-test('opponent race filter narrows results', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  await page.getByLabel('Opponent Race').selectOption('Human');
-  await page.getByRole('button', { name: 'Filter' }).click();
-  const table = page.getByRole('table', { name: 'Games' });
-  await expect(table).toContainText('BB3 Extra 5');
-  await expect(table).not.toContainText('Skaven Game');
+test("opponent race filter narrows results", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  await page.getByLabel("Opponent Race").selectOption("Human");
+  await page.getByRole("button", { name: "Filter" }).click();
+  const table = page.getByRole("table", { name: "Games" });
+  await expect(table).toContainText("BB3 Extra 5");
+  await expect(table).not.toContainText("Skaven Game");
 });
 
-test('clear link resets all filters', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  await page.getByLabel('Platform').selectOption('Blood Bowl 3');
-  await page.getByRole('button', { name: 'Filter' }).click();
-  await page.getByRole('link', { name: 'Clear' }).click();
-  await expect(page).toHaveURL('/blood-bowl');
+test("clear link resets all filters", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  await page.getByLabel("Platform").selectOption("Blood Bowl 3");
+  await page.getByRole("button", { name: "Filter" }).click();
+  await page.getByRole("link", { name: "Clear" }).click();
+  await expect(page).toHaveURL("/blood-bowl");
 });
 
-test('filters are preserved in pagination links', async ({ page }) => {
+test("filters are preserved in pagination links", async ({ page }) => {
   // 11 seeded BB3 games trigger a second page when filtering by platform
-  await page.goto('/blood-bowl');
-  await page.getByLabel('Platform').selectOption('Blood Bowl 3');
-  await page.getByRole('button', { name: 'Filter' }).click();
-  const nextHref = await page.getByRole('link', { name: /Next/ }).getAttribute('href');
-  expect(nextHref).toContain('platform=Blood+Bowl+3');
+  await page.goto("/blood-bowl");
+  await page.getByLabel("Platform").selectOption("Blood Bowl 3");
+  await page.getByRole("button", { name: "Filter" }).click();
+  const nextHref = await page.getByRole("link", { name: /Next/ }).getAttribute("href");
+  expect(nextHref).toContain("platform=Blood+Bowl+3");
 });
 
 // --- Format options scoped to platform ---
 
-test('selecting a platform updates format options to match', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  await page.getByLabel('Platform').selectOption('tabletop');
-  const labels = await page.getByLabel('Format').locator('option').allTextContents();
-  expect(labels).toContain('tournament');
-  expect(labels).not.toContain('ladder'); // ladder is BB3/Fumbbl only
+test("selecting a platform updates format options to match", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  await page.getByLabel("Platform").selectOption("tabletop");
+  const labels = await page.getByLabel("Format").locator("option").allTextContents();
+  expect(labels).toContain("tournament");
+  expect(labels).not.toContain("ladder"); // ladder is BB3/Fumbbl only
 });
 
-test('format dropdown shows all options when no platform is selected', async ({ page }) => {
-  await page.goto('/blood-bowl');
-  const labels = await page.getByLabel('Format').locator('option').allTextContents();
-  expect(labels).toContain('league');
-  expect(labels).toContain('tournament');
+test("format dropdown shows all options when no platform is selected", async ({ page }) => {
+  await page.goto("/blood-bowl");
+  const labels = await page.getByLabel("Format").locator("option").allTextContents();
+  expect(labels).toContain("league");
+  expect(labels).toContain("tournament");
 });

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,8 +1,8 @@
-import path from 'path';
-import { execSync } from 'child_process';
-import fs from 'fs';
+import path from "path";
+import { execSync } from "child_process";
+import fs from "fs";
 
-const TEST_DB = path.join(process.cwd(), 'data', 'test.db');
+const TEST_DB = path.join(process.cwd(), "data", "test.db");
 
 function runSeed(cmd: string) {
   execSync(cmd, { env: { ...process.env, DB_PATH: TEST_DB } });
@@ -10,6 +10,6 @@ function runSeed(cmd: string) {
 
 export default function globalSetup() {
   if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
-  runSeed('npx tsx src/lib/seed.ts');      // schema + reference data
-  runSeed('node scripts/seed-test.js');    // known test games
+  runSeed("npx tsx src/lib/seed.ts"); // schema + reference data
+  runSeed("node scripts/seed-test.js"); // known test games
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@components/*": ["src/components/*"],
-      "@layouts/*": ["src/layouts/*"], 
+      "@layouts/*": ["src/layouts/*"],
       "@styles/*": ["src/styles/*"],
       "@utils/*": ["src/utils/*"]
     },


### PR DESCRIPTION
## Summary

- Installs `oxfmt` (OXC formatter) as a dev dependency
- Adds `.oxfmtrc.json` config (default settings, initialized via `oxfmt --init`)
- Adds `npm run format` and `npm run format:check` scripts
- Applies initial formatting pass across the codebase

## Notes

`oxfmt` covers `.js`, `.ts`, `.md`, and `.json` files. `.astro` files are not supported by oxfmt and remain unformatted.

## Test plan

- [x] `npm run format:check` exits clean after the formatting pass
- [x] All 18 Playwright tests pass after reformatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)