### PR TITLE
Add win rate by opponent race summary

### DIFF
--- a/src/components/StatsCard.astro
+++ b/src/components/StatsCard.astro
@@ -47,57 +47,59 @@ const overallWinRateClass = winRateClass(winRateValue);
     {winRate !== null && <span class={`win-rate ${overallWinRateClass}`}>({winRate}%)</span>}
   </div>
 
-  {byMyRace.length > 0 && (
-    <div class="race-summary">
-      <h3>Playing As</h3>
-      <ul class="race-list">
-        {sortByWinRate(byMyRace).map(r => {
-          const rv = raceWinRate(r);
-          return (
-            <li class="race-row">
-              <span class="race-name">{r.race}</span>
-              <span class={`race-winrate ${winRateClass(rv)}`}>
-                {rv !== null ? `${rv.toFixed(1)}%` : "—"}
-              </span>
-              <span class="race-record">
-                <span class="w">{r.w}W</span>
-                <span class="sep">/</span>
-                <span class="d">{r.d}D</span>
-                <span class="sep">/</span>
-                <span class="l">{r.l}L</span>
-              </span>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  )}
+  <div class="race-summaries">
+    {byMyRace.length > 0 && (
+      <div class="race-summary">
+        <h3>Playing As</h3>
+        <ul class="race-list">
+          {sortByWinRate(byMyRace).map(r => {
+            const rv = raceWinRate(r);
+            return (
+              <li class="race-row">
+                <span class="race-name">{r.race}</span>
+                <span class={`race-winrate ${winRateClass(rv)}`}>
+                  {rv !== null ? `${rv.toFixed(1)}%` : "—"}
+                </span>
+                <span class="race-record">
+                  <span class="w">{r.w}W</span>
+                  <span class="sep">/</span>
+                  <span class="d">{r.d}D</span>
+                  <span class="sep">/</span>
+                  <span class="l">{r.l}L</span>
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    )}
 
-  {byRace.length > 0 && (
-    <div class="race-summary">
-      <h3>Against</h3>
-      <ul class="race-list">
-        {sortByWinRate(byRace).map(r => {
-          const rv = raceWinRate(r);
-          return (
-            <li class="race-row">
-              <span class="race-name">{r.race}</span>
-              <span class={`race-winrate ${winRateClass(rv)}`}>
-                {rv !== null ? `${rv.toFixed(1)}%` : "—"}
-              </span>
-              <span class="race-record">
-                <span class="w">{r.w}W</span>
-                <span class="sep">/</span>
-                <span class="d">{r.d}D</span>
-                <span class="sep">/</span>
-                <span class="l">{r.l}L</span>
-              </span>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  )}
+    {byRace.length > 0 && (
+      <div class="race-summary">
+        <h3>Against</h3>
+        <ul class="race-list">
+          {sortByWinRate(byRace).map(r => {
+            const rv = raceWinRate(r);
+            return (
+              <li class="race-row">
+                <span class="race-name">{r.race}</span>
+                <span class={`race-winrate ${winRateClass(rv)}`}>
+                  {rv !== null ? `${rv.toFixed(1)}%` : "—"}
+                </span>
+                <span class="race-record">
+                  <span class="w">{r.w}W</span>
+                  <span class="sep">/</span>
+                  <span class="d">{r.d}D</span>
+                  <span class="sep">/</span>
+                  <span class="l">{r.l}L</span>
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    )}
+  </div>
 </div>
 
 <style>
@@ -123,9 +125,15 @@ const overallWinRateClass = winRateClass(winRateValue);
   .win-rate-positive { color: #3a9a3a; }
   .win-rate-negative { color: #c0392b; }
   .win-rate-neutral { color: var(--text-muted, #888); }
+  .race-summaries {
+    display: grid;
+    grid-template-columns: repeat(2, auto);
+    gap: 2rem;
+    margin-top: 1rem;
+  }
   .race-summary h3 {
     font-size: 1rem;
-    margin: 1.25rem 0 0.5rem;
+    margin: 0 0 0.5rem;
   }
   .race-list {
     list-style: none;

--- a/src/components/StatsCard.astro
+++ b/src/components/StatsCard.astro
@@ -16,13 +16,19 @@ const { overall, byRace } = Astro.props;
 function raceWinRate(r: RaceRecord) {
   const total = r.w + r.d + r.l;
   if (total === 0) return null;
-  return (r.w + r.d * 0.5) / total * 100;
+  return ((r.w + r.d * 0.5) / total) * 100;
 }
 
 function winRateClass(value: number | null) {
   if (value === null || value === 50) return "win-rate-neutral";
   return value > 50 ? "win-rate-positive" : "win-rate-negative";
 }
+
+const byRaceSorted = [...byRace].sort((a, b) => {
+  const ra = raceWinRate(a) ?? -1;
+  const rb = raceWinRate(b) ?? -1;
+  return rb - ra;
+});
 
 const totalGames = overall.w + overall.d + overall.l;
 const winRateValue =
@@ -42,32 +48,30 @@ const overallWinRateClass = winRateClass(winRateValue);
     {winRate !== null && <span class={`win-rate ${overallWinRateClass}`}>({winRate}%)</span>}
   </div>
 
-  {byRace.length > 0 && (
-    <table class="race-breakdown">
-      <thead>
-        <tr>
-          <th>Race</th>
-          <th>W</th>
-          <th>D</th>
-          <th>L</th>
-          <th>Win%</th>
-        </tr>
-      </thead>
-      <tbody>
-        {byRace.map(r => {
+  {byRaceSorted.length > 0 && (
+    <div class="race-summary">
+      <h3>Win Rate by Opponent Race</h3>
+      <ul class="race-list">
+        {byRaceSorted.map(r => {
           const rv = raceWinRate(r);
           return (
-            <tr>
-              <td>{r.race}</td>
-              <td class="w">{r.w}</td>
-              <td class="d">{r.d}</td>
-              <td class="l">{r.l}</td>
-              <td class={winRateClass(rv)}>{rv !== null ? `${rv.toFixed(1)}%` : "—"}</td>
-            </tr>
+            <li class="race-row">
+              <span class="race-name">{r.race}</span>
+              <span class={`race-winrate ${winRateClass(rv)}`}>
+                {rv !== null ? `${rv.toFixed(1)}%` : "—"}
+              </span>
+              <span class="race-record">
+                <span class="w">{r.w}W</span>
+                <span class="sep">/</span>
+                <span class="d">{r.d}D</span>
+                <span class="sep">/</span>
+                <span class="l">{r.l}L</span>
+              </span>
+            </li>
           );
         })}
-      </tbody>
-    </table>
+      </ul>
+    </div>
   )}
 </div>
 
@@ -94,16 +98,34 @@ const overallWinRateClass = winRateClass(winRateValue);
   .win-rate-positive { color: #3a9a3a; }
   .win-rate-negative { color: #c0392b; }
   .win-rate-neutral { color: var(--text-muted, #888); }
-  .race-breakdown {
-    border-collapse: collapse;
+  .race-summary h3 {
+    font-size: 1rem;
+    margin: 1.25rem 0 0.5rem;
   }
-  .race-breakdown th,
-  .race-breakdown td {
-    padding: 0.25rem 0.75rem;
-    text-align: left;
-    border-bottom: 1px solid var(--border, #eee);
+  .race-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
   }
-  .race-breakdown th {
+  .race-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+  }
+  .race-name {
+    width: 14rem;
+    font-size: 0.9rem;
+  }
+  .race-winrate {
     font-weight: bold;
+    font-size: 0.95rem;
+    width: 4rem;
+  }
+  .race-record {
+    font-size: 0.8rem;
+    color: var(--text-muted, #888);
   }
 </style>

--- a/src/components/StatsCard.astro
+++ b/src/components/StatsCard.astro
@@ -8,10 +8,11 @@ interface RaceRecord {
 
 interface Props {
   overall: { w: number; l: number; d: number };
+  byMyRace: RaceRecord[];
   byRace: RaceRecord[];
 }
 
-const { overall, byRace } = Astro.props;
+const { overall, byMyRace, byRace } = Astro.props;
 
 function raceWinRate(r: RaceRecord) {
   const total = r.w + r.d + r.l;
@@ -24,11 +25,9 @@ function winRateClass(value: number | null) {
   return value > 50 ? "win-rate-positive" : "win-rate-negative";
 }
 
-const byRaceSorted = [...byRace].sort((a, b) => {
-  const ra = raceWinRate(a) ?? -1;
-  const rb = raceWinRate(b) ?? -1;
-  return rb - ra;
-});
+function sortByWinRate(rows: RaceRecord[]) {
+  return [...rows].sort((a, b) => (raceWinRate(b) ?? -1) - (raceWinRate(a) ?? -1));
+}
 
 const totalGames = overall.w + overall.d + overall.l;
 const winRateValue =
@@ -48,11 +47,37 @@ const overallWinRateClass = winRateClass(winRateValue);
     {winRate !== null && <span class={`win-rate ${overallWinRateClass}`}>({winRate}%)</span>}
   </div>
 
-  {byRaceSorted.length > 0 && (
+  {byMyRace.length > 0 && (
     <div class="race-summary">
-      <h3>Win Rate by Opponent Race</h3>
+      <h3>Playing As</h3>
       <ul class="race-list">
-        {byRaceSorted.map(r => {
+        {sortByWinRate(byMyRace).map(r => {
+          const rv = raceWinRate(r);
+          return (
+            <li class="race-row">
+              <span class="race-name">{r.race}</span>
+              <span class={`race-winrate ${winRateClass(rv)}`}>
+                {rv !== null ? `${rv.toFixed(1)}%` : "—"}
+              </span>
+              <span class="race-record">
+                <span class="w">{r.w}W</span>
+                <span class="sep">/</span>
+                <span class="d">{r.d}D</span>
+                <span class="sep">/</span>
+                <span class="l">{r.l}L</span>
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  )}
+
+  {byRace.length > 0 && (
+    <div class="race-summary">
+      <h3>Against</h3>
+      <ul class="race-list">
+        {sortByWinRate(byRace).map(r => {
           const rv = raceWinRate(r);
           return (
             <li class="race-row">

--- a/src/pages/blood-bowl/index.astro
+++ b/src/pages/blood-bowl/index.astro
@@ -38,23 +38,31 @@ const uniqueMyRaces       = [...new Set(allGames.map(g => g.my_race))].sort();
 const uniqueOpponentRaces = [...new Set(allGames.map(g => g.opponent_race))].sort();
 
 const overall = { w: 0, l: 0, d: 0 };
-const raceMap = new Map<string, { w: number; l: number; d: number }>();
+const myRaceMap  = new Map<string, { w: number; l: number; d: number }>();
+const oppRaceMap = new Map<string, { w: number; l: number; d: number }>();
+
+function tally(map: Map<string, { w: number; l: number; d: number }>, key: string, result: string) {
+  if (!map.has(key)) map.set(key, { w: 0, l: 0, d: 0 });
+  const rec = map.get(key)!;
+  if (result === 'W') rec.w++;
+  else if (result === 'L') rec.l++;
+  else rec.d++;
+}
 
 for (const g of games) {
   if (g.result === 'W') overall.w++;
   else if (g.result === 'L') overall.l++;
   else overall.d++;
 
-  if (!raceMap.has(g.opponent_race)) {
-    raceMap.set(g.opponent_race, { w: 0, l: 0, d: 0 });
-  }
-  const rec = raceMap.get(g.opponent_race)!;
-  if (g.result === 'W') rec.w++;
-  else if (g.result === 'L') rec.l++;
-  else rec.d++;
+  tally(myRaceMap,  g.my_race,       g.result);
+  tally(oppRaceMap, g.opponent_race, g.result);
 }
 
-const byRace = Array.from(raceMap.entries())
+const byMyRace = Array.from(myRaceMap.entries())
+  .map(([race, rec]) => ({ race, ...rec }))
+  .sort((a, b) => a.race.localeCompare(b.race));
+
+const byRace = Array.from(oppRaceMap.entries())
   .map(([race, rec]) => ({ race, ...rec }))
   .sort((a, b) => a.race.localeCompare(b.race));
 
@@ -78,7 +86,7 @@ function pageUrl(p: number) {
 
 <BaseLayout title="Blood Bowl">
   <h1>Blood Bowl</h1>
-  <StatsCard overall={overall} byRace={byRace} />
+  <StatsCard overall={overall} byMyRace={byMyRace} byRace={byRace} />
   <h2>Games</h2>
   <form class="filters" method="get">
     <label>


### PR DESCRIPTION
## Summary

Replaces the old alphabetical W/D/L race table with a dedicated "Win Rate by Opponent Race" summary section that:

- Sorts races by win rate descending (best matchups first)
- Shows win% prominently with green/red/grey color coding (same convention as overall win rate)
- Shows the raw W/D/L record as secondary info

## Test plan

- [x] All 18 Playwright tests pass
- [x] Visually verified with real dev DB data (30 opponent races shown, sorted correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)